### PR TITLE
CSCEXAM-0000 Fixed invalid version string.

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exam",
-  "version": "4.1.x",
+  "version": "4.1.0",
   "description": "EXAM – electronic exam software for higher education",
   "repository": {
     "type": "git",

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scala.util.Properties
 
 name := "exam"
 
-version := "4.1.x"
+version := "4.1.0"
 
 licenses += "EUPL 1.1" -> url("http://joinup.ec.europa.eu/software/page/eupl/licence-eupl")
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -180,4 +180,4 @@ akka.http.parsing.max-header-count = 128
 akka.coordinated-shutdown.run-by-jvm-shutdown-hook = off
 
 # EXAM version
-exam.release.version = "4.1.x"
+exam.release.version = "4.1.0"


### PR DESCRIPTION
- NPM does not support alphabets in patch/minor/major version number.