### PR TITLE
CSCEXAM-96 fix candidate for removing duplicate language inspections

### DIFF
--- a/app/controllers/LanguageInspectionController.java
+++ b/app/controllers/LanguageInspectionController.java
@@ -21,6 +21,7 @@ import be.objectify.deadbolt.java.actions.Group;
 import be.objectify.deadbolt.java.actions.Pattern;
 import be.objectify.deadbolt.java.actions.Restrict;
 import controllers.base.BaseController;
+import impl.EmailComposer;
 import io.ebean.Ebean;
 import io.ebean.ExpressionList;
 import models.Comment;
@@ -33,11 +34,9 @@ import play.data.DynamicForm;
 import play.mvc.Result;
 import scala.concurrent.duration.Duration;
 import util.AppUtil;
-import impl.EmailComposer;
 
 import javax.inject.Inject;
 import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +64,6 @@ public class LanguageInspectionController extends BaseController {
                 .ne("exam.state", Exam.State.DELETED);
 
         if (start.isPresent() || end.isPresent()) {
-            long x = 100;
             if (start.isPresent()) {
                 DateTime startDate = new DateTime(start.get()).withTimeAtStartOfDay();
                 query = query.ge("finishedAt", startDate.toDate());
@@ -88,7 +86,7 @@ public class LanguageInspectionController extends BaseController {
                     .endJunction();
         }
 
-        List<LanguageInspection> inspections = query.findList();
+        Set<LanguageInspection> inspections = query.findSet();
         return ok(inspections);
     }
 

--- a/app/models/LanguageInspection.java
+++ b/app/models/LanguageInspection.java
@@ -17,6 +17,8 @@ package models;
 
 
 import models.base.OwnedModel;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
@@ -92,4 +94,25 @@ public class LanguageInspection extends OwnedModel {
     public void setAssignee(User assignee) {
         this.assignee = assignee;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (!(o instanceof LanguageInspection)) return false;
+
+        LanguageInspection that = (LanguageInspection) o;
+
+        return new EqualsBuilder()
+                .append(id, that.id)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(id)
+                .toHashCode();
+    }
+
 }


### PR DESCRIPTION
- probable issue with Ebean and outer joins
- fetch results as a set instead of a list + implement the usual equals+hashcode for comparison.