### PR TITLE
CSCEXAM-65 disable paste commands when editing cloze test text

### DIFF
--- a/public/components/vendor/ckeditor/plugins/clozetest/plugin.js
+++ b/public/components/vendor/ckeditor/plugins/clozetest/plugin.js
@@ -22,8 +22,13 @@ CKEDITOR.plugins.add( 'clozetest', {
                 command: 'insertCloze',
                 group: 'clozeGroup'
             });
+
+            var selector = function (el) {
+                return el.getName && el.getName() === 'span' && el.getAttribute('cloze') === 'true';
+            };
+
             editor.contextMenu.addListener( function( element ) {
-                if ( element.getAscendant( 'span', true ) ) {
+                if ( element.getAscendant( selector, true ) ) {
                     return { clozeItem: CKEDITOR.TRISTATE_OFF };
                 }
             });


### PR DESCRIPTION
- only allow paste as plain text command
- also put some extra checking when entering edit mode