### PR TITLE
Hide anonymous review checkbox from normal exam.

### DIFF
--- a/app/frontend/src/exam/editor/basic/basicExamInfo.component.ts
+++ b/app/frontend/src/exam/editor/basic/basicExamInfo.component.ts
@@ -152,6 +152,10 @@ export const BasicExamInfoComponent: ng.IComponentOptions = {
             this.updateExam(true);
         }
 
+        showAnonymousReview = () => {
+            return this.collaborative || (this.exam.executionType.type === 'PUBLIC' && this.anonymousReviewEnabled);
+        }
+
         toggleAnonymous = () => {
             this.updateExam(false);
         }

--- a/app/frontend/src/exam/editor/basic/basicExamInfo.template.html
+++ b/app/frontend/src/exam/editor/basic/basicExamInfo.template.html
@@ -42,7 +42,7 @@
         </div>
 
         <!-- ANONYMOUS REVIEW -->
-        <div class="row col-md-12 margin-20" ng-show="$ctrl.exam.executionType.type==='PUBLIC'">
+        <div class="row col-md-12 margin-20" ng-show="$ctrl.showAnonymousReview()">
             <div class="col-md-3 exam-basic-title">{{'sitnet_anonymous_review' | translate}}
             </div>
             <div class="col-md-9">


### PR DESCRIPTION
- If global anonymous setting is not enabled normal exam does not show anonymous review checkbox.
- Collaborative exam shows always anonymous review checkbox.