### PR TITLE
CSCEXAM-176 fix validation of number inputs

### DIFF
--- a/app/frontend/src/question/basequestion/questionBody.template.html
+++ b/app/frontend/src/question/basequestion/questionBody.template.html
@@ -14,8 +14,7 @@
 
         <div class="col-md-12">
             <div class="col-md-1">
-                <img src="Images/icon_warning.png" alt="exam"
-                     onerror="this.onerror=null;this.src='Images/icon_warning.svg';"/>
+                <img src="Images/icon_warning.png" alt="exam" onerror="this.onerror=null;this.src='Images/icon_warning.svg';" />
             </div>
             <div class="col-md-11 warning-text">
                 {{'sitnet_exam_question_edit_instructions' | translate}}
@@ -57,16 +56,13 @@
     <div class="col-md-3 exam-basic-title padl0">
         {{'sitnet_new_question_type' | translate}}
         <sup>
-            <img popover-placement="right" popover-trigger="'mouseenter'"
-                 uib-popover="{{'sitnet_question_type_description' | translate}}"
-                 src="Images/icon_tooltip.svg" alt="exam"
-                 onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"/>
+            <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_question_type_description' | translate}}"
+                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
         </sup>
     </div>
     <div class="col-md-9 padr0">
-        <select ng-if="!$ctrl.question.type" id="newQuestion" name="newQuestion" class="form-control wdtin"
-                ng-model="$ctrl.newType"
-                ng-change="$ctrl.setQuestionType()" ng-options="type.name | translate for type in $ctrl.questionTypes">
+        <select ng-if="!$ctrl.question.type" id="newQuestion" name="newQuestion" class="form-control wdtin" ng-model="$ctrl.newType"
+            ng-change="$ctrl.setQuestionType()" ng-options="type.name | translate for type in $ctrl.questionTypes">
             <option value="">{{'sitnet_choose' | translate}}</option>
         </select>
         <span ng-if="$ctrl.question.type == 'EssayQuestion'">
@@ -87,17 +83,14 @@
         <div class="col-md-3 exam-basic-title padl0">
             {{'sitnet_question_text' | translate}}
             <sup>
-                <img popover-placement="right" popover-trigger="'mouseenter'"
-                     uib-popover="{{'sitnet_question_text_description' | translate}}"
-                     src="Images/icon_tooltip.svg" alt="exam"
-                     onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                />
+                <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_question_text_description' | translate}}"
+                    src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
             </sup>
         </div>
         <div class="col-md-9 padr0">
-            <textarea id="editor" name="editor" ck-editor
-                      enable-cloze-test="$ctrl.question.type === 'ClozeTestQuestion'" rows="10" cols="60"
-                      ng-model="$ctrl.question.question" required>
+            <textarea id="editor" name="editor" ck-editor enable-cloze-test="$ctrl.question.type === 'ClozeTestQuestion'"
+                rows="10" cols="60" ng-model="$ctrl.question.question" required>
+
             </textarea>
         </div>
     </div>
@@ -121,13 +114,11 @@
     <!-- Type specific content -->
     <div ng-switch="$ctrl.question.type">
         <essay-form ng-switch-when="EssayQuestion" question="$ctrl.question"></essay-form>
-        <multiple-choice-form ng-switch-when="MultipleChoiceQuestion" question="$ctrl.question"
-                              show-warning="$ctrl.showWarning()"
-                              lottery-on="$ctrl.lotteryOn" allow-option-removal="!$ctrl.isInPublishedExam">
+        <multiple-choice-form ng-switch-when="MultipleChoiceQuestion" question="$ctrl.question" show-warning="$ctrl.showWarning()"
+            lottery-on="$ctrl.lotteryOn" allow-option-removal="!$ctrl.isInPublishedExam">
         </multiple-choice-form>
-        <multiple-choice-form ng-switch-when="WeightedMultipleChoiceQuestion" question="$ctrl.question"
-                              show-warning="$ctrl.showWarning()"
-                              lottery-on="$ctrl.lotteryOn" allow-option-removal="!$ctrl.isInPublishedExam">
+        <multiple-choice-form ng-switch-when="WeightedMultipleChoiceQuestion" question="$ctrl.question" show-warning="$ctrl.showWarning()"
+            lottery-on="$ctrl.lotteryOn" allow-option-removal="!$ctrl.isInPublishedExam">
         </multiple-choice-form>
     </div>
 
@@ -138,8 +129,7 @@
         </div>
         <div class="col-md-9">
             <select id="evaluationType" class="form-control wdt240" ng-model="$ctrl.question.defaultEvaluationType"
-                    ng-change="$ctrl.updateEvaluationType()"
-                    ng-required="$ctrl.question.type == 'EssayQuestion'">
+                ng-change="$ctrl.updateEvaluationType()" ng-required="$ctrl.question.type == 'EssayQuestion'">
                 <option value="Points">{{ 'sitnet_word_points' | translate }}</option>
                 <option value="Selection">{{ 'sitnet_evaluation_select' | translate }}</option>
             </select>
@@ -154,9 +144,8 @@
             {{'sitnet_max_score' | translate}}
         </div>
         <div class="col-md-9">
-            <input id="defaultMaxScore" name="defaultMaxScore" type="number" class="form-control wdt100"
-                   ng-model="$ctrl.question.defaultMaxScore"
-                   step="1" min="0" max="1000" fixed-precision required ng-disabled="$ctrl.lotteryOn"/>
+            <input id="defaultMaxScore" name="defaultMaxScore" type="number" class="form-control wdt100" ng-model="$ctrl.question.defaultMaxScore"
+                min="0" max="1000" fixed-precision required ng-disabled="$ctrl.lotteryOn" />
         </div>
     </div>
 
@@ -170,20 +159,16 @@
     <div class="col-md-12 margin-20 padl0 padr0">
         <div class="col-md-3 exam-basic-title padl0">{{'sitnet_question_owners' | translate}}
             <sup>
-                <img popover-placement="right" popover-trigger="'mouseenter'"
-                     uib-popover="{{'sitnet_question_owners_description' | translate}}"
-                     src="Images/icon_tooltip.svg" alt="exam"
-                     onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                />
+                <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_question_owners_description' | translate}}"
+                    src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
             </sup>
         </div>
         <div class="col-md-9" ng-if="$ctrl.isUserAllowedToModifyOwners()">
-            <input type="text" class="form-control wdth-30 make-inline" ng-model="$ctrl.newOwner.name"
-                   uib-typeahead="t.name for t in $ctrl.questionOwners('name', $viewValue)"
-                   typeahead-editable="false" typeahead-min-length="2"
-                   typeahead-on-select="$ctrl.setQuestionOwner($item, $model, $label)">
+            <input type="text" class="form-control wdth-30 make-inline" ng-model="$ctrl.newOwner.name" uib-typeahead="t.name for t in $ctrl.questionOwners('name', $viewValue)"
+                typeahead-editable="false" typeahead-min-length="2" typeahead-on-select="$ctrl.setQuestionOwner($item, $model, $label)">
             <span>
-                <button ng-click="$ctrl.addQuestionOwner()" class="btn btn-primary green border-green">{{'sitnet_add' | translate}}</button>
+                <button ng-click="$ctrl.addQuestionOwner()" class="btn btn-primary green border-green">{{'sitnet_add' |
+                    translate}}</button>
             </span>
         </div>
         <div class="col-md-9" ng-if="!$ctrl.isUserAllowedToModifyOwners()">
@@ -197,17 +182,15 @@
         <div class="col-md-9" ng-if="$ctrl.isUserAllowedToModifyOwners()">
             <ul class="list-inline mart10 padl10">
                 <li ng-repeat="user in $ctrl.currentOwners track by $index">{{user.firstName }} {{ user.lastName }}
-                    <button class="reviewer-remove" ng-disabled="$ctrl.removeOwnerDisabled(user)"
-                            ng-click="$ctrl.removeOwner(user)" title="{{'sitnet_remove' | translate}}">
-                        <img src="Images/icon_remove.svg" alt="exam"
-                             onerror="this.onerror=null;this.src='Images/icon_remove.png';"/>
+                    <button class="reviewer-remove" ng-disabled="$ctrl.removeOwnerDisabled(user)" ng-click="$ctrl.removeOwner(user)"
+                        title="{{'sitnet_remove' | translate}}">
+                        <img src="Images/icon_remove.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_remove.png';" />
                     </button>
                 </li>
             </ul>
         </div>
         <div class="col-md-9" ng-if="!$ctrl.isUserAllowedToModifyOwners()">
-            <span ng-repeat="user in $ctrl.questionOwners track by $index" class="label label-default"
-                  style="margin: 0.2em">
+            <span ng-repeat="user in $ctrl.questionOwners track by $index" class="label label-default" style="margin: 0.2em">
                 {{user.firstName }} {{ user.lastName }}
             </span>
         </div>
@@ -218,11 +201,8 @@
         <div class="col-md-3 exam-basic-title padl0">
             {{ 'sitnet_question_attachment' | translate}}
             <sup>
-                <img popover-placement="right" popover-trigger="'mouseenter'"
-                     uib-popover="{{'sitnet_attachment_description' | translate}}"
-                     src="Images/icon_tooltip.svg" alt="exam"
-                     onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                />
+                <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_attachment_description' | translate}}"
+                    src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
             </sup>
         </div>
 
@@ -232,8 +212,7 @@
             </div>
             <div ng-show="$ctrl.question.attachment && !$ctrl.question.attachment.removed" class="make-inline padl10">
                 <!-- Uploaded -->
-                <a ng-if="$ctrl.hasUploadedAttachment()" class="pointer attachment-link"
-                   ng-click="$ctrl.downloadQuestionAttachment()">
+                <a ng-if="$ctrl.hasUploadedAttachment()" class="pointer attachment-link" ng-click="$ctrl.downloadQuestionAttachment()">
                     <i class="fa fa-paperclip fa-fw"></i> {{$ctrl.question.attachment.fileName}}
                 </a>
                 <!-- Not yet uploaded -->
@@ -243,9 +222,7 @@
                         ({{ $ctrl.getFileSize() }})</small>
                 </span>
                 <span class="pointer remove-attachment" ng-click="$ctrl.removeQuestionAttachment()">
-                    <img src="Images/icon_remove.svg" alt="{{'sitnet_remove_attachment' | translate }}"
-                         onerror="this.onerror=null;this.src='Images/icon_remove.png';"
-                    />
+                    <img src="Images/icon_remove.svg" alt="{{'sitnet_remove_attachment' | translate }}" onerror="this.onerror=null;this.src='Images/icon_remove.png';" />
                 </span>
             </div>
             <div class="mart10" ng-if="$ctrl.showWarning()">
@@ -260,17 +237,14 @@
         <div class="col-md-3 exam-basic-title padl0">
             {{ 'sitnet_question_instruction' | translate}}
             <sup>
-                <img popover-placement="right" popover-trigger="'mouseenter'"
-                     uib-popover="{{'sitnet_question_instruction_description' | translate}}"
-                     src="Images/icon_tooltip.svg" alt="exam"
-                     onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                />
+                <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_question_instruction_description' | translate}}"
+                    src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
             </sup>
         </div>
         <div class="col-md-9 padr0">
-            <textarea id="defaultInstructions" class="form-control" rows="3"
-                      ng-model="$ctrl.question.defaultAnswerInstructions"
-                      placeholder="{{'sitnet_question_instruction' | translate}}">
+            <textarea id="defaultInstructions" class="form-control" rows="3" ng-model="$ctrl.question.defaultAnswerInstructions"
+                placeholder="{{'sitnet_question_instruction' | translate}}">
+
                 </textarea>
         </div>
     </div>
@@ -281,17 +255,14 @@
         <div class="col-md-3 exam-basic-title padl0">
             {{ 'sitnet_exam_evaluation_criteria' | translate}}
             <sup>
-                <img popover-placement="right" popover-trigger="'mouseenter'"
-                     uib-popover="{{'sitnet_question_evaluation_criteria_description' | translate}}"
-                     src="Images/icon_tooltip.svg" alt="exam"
-                     onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                />
+                <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_question_evaluation_criteria_description' | translate}}"
+                    src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
             </sup>
         </div>
         <div class="col-md-9 padr0">
-            <textarea id="defaultEvaluationCriteria" class="form-control" rows="3"
-                      ng-model="$ctrl.question.defaultEvaluationCriteria"
-                      placeholder="{{'sitnet_exam_evaluation_criteria' | translate}}">
+            <textarea id="defaultEvaluationCriteria" class="form-control" rows="3" ng-model="$ctrl.question.defaultEvaluationCriteria"
+                placeholder="{{'sitnet_exam_evaluation_criteria' | translate}}">
+
         </textarea>
         </div>
     </div>

--- a/app/frontend/src/question/basequestion/weightedMultipleChoiceOptionForm.component.js
+++ b/app/frontend/src/question/basequestion/weightedMultipleChoiceOptionForm.component.js
@@ -27,7 +27,7 @@ angular.module('app.question')
                 </div>
                 <div class="col-md-2 question-option-empty-radio" ng-class="$ctrl.option.defaultScore > 0 ? 'question-correct-option-radio' : ''">
                     <input id="optionScore" name="maxScore" class="question-option-input points"
-                       type="number" step="1"
+                       type="number"
                        ng-model="$ctrl.option.defaultScore"
                        fixed-precision
                        required="true"

--- a/app/frontend/src/question/examquestion/examQuestion.template.html
+++ b/app/frontend/src/question/examquestion/examQuestion.template.html
@@ -88,13 +88,14 @@
                         {{'sitnet_new_question_type' | translate}}
                         <sup>
                             <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_question_type_description' | translate}}"
-                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                            />
+                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
                         </sup>
                     </div>
                     <div class="col-md-9 padr0">
-                        <span ng-if="$ctrl.question.type == 'EssayQuestion'">{{'sitnet_toolbar_essay_question' | translate}}</span>
-                        <span ng-if="$ctrl.question.type == 'ClozeTestQuestion'">{{'sitnet_toolbar_cloze_test_question' |
+                        <span ng-if="$ctrl.question.type == 'EssayQuestion'">{{'sitnet_toolbar_essay_question' |
+                            translate}}</span>
+                        <span ng-if="$ctrl.question.type == 'ClozeTestQuestion'">{{'sitnet_toolbar_cloze_test_question'
+                            |
                             translate}}</span>
                         <span ng-if="$ctrl.question.type == 'MultipleChoiceQuestion'">{{'sitnet_toolbar_multiplechoice_question'
                             | translate}}</span>
@@ -107,13 +108,13 @@
                         {{'sitnet_question_text' | translate}}
                         <sup>
                             <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_question_text_description' | translate}}"
-                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                            />
+                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
                         </sup>
                     </div>
                     <div class="col-md-9 padr0" ng-show="$ctrl.question.type">
-                        <textarea id="editor" name="editor" ck-editor enable-cloze-test="$ctrl.question.type === 'ClozeTestQuestion'" rows="10" cols="60"
-                            ng-model="$ctrl.question.question" required>
+                        <textarea id="editor" name="editor" ck-editor enable-cloze-test="$ctrl.question.type === 'ClozeTestQuestion'"
+                            rows="10" cols="60" ng-model="$ctrl.question.question" required>
+
                         </textarea>
                     </div>
                 </div>
@@ -133,10 +134,11 @@
                     </div>
                     <div class="col-lg-5 col-md-7">
                         <div class="input-group" id="expectedWordCount">
-                            <input name="expectedWordCount" type="number" class="form-control" ng-model="$ctrl.examQuestion.expectedWordCount" min="1"
-                                max="1000000">
+                            <input name="expectedWordCount" type="number" class="form-control" ng-model="$ctrl.examQuestion.expectedWordCount"
+                                min="1" max="1000000">
                             <span class="input-group-addon" title="{{'sitnet_average_word_length_finnish' | translate}}">
-                                {{'sitnet_approximately' | translate}} {{$ctrl.estimateCharacters()}} {{'sitnet_characters' | translate}}
+                                {{'sitnet_approximately' | translate}} {{$ctrl.estimateCharacters()}}
+                                {{'sitnet_characters' | translate}}
                             </span>
                         </div>
                         <div ng-hide="questionForm.expectedWordCount.$valid" class="warning-text-small margin-10">
@@ -158,7 +160,7 @@
                 <div class="col-md-12 mart20 marb10" ng-if="$ctrl.question.type === 'WeightedMultipleChoiceQuestion'">
                     <div class="col-md-6 padl0">
                         <span class="question-option-title">{{'sitnet_option' | translate}}</span>
-                        <br/>
+                        <br />
                         <span ng-if="showWarning()">
                             <i class="fa fa-exclamation-circle reddish"></i>
                             <small>{{'sitnet_shared_question_property_info' | translate}}</small>
@@ -174,12 +176,13 @@
                     <div class="col-md-12 form-horizontal question-editor-option" ng-repeat="option in $ctrl.examQuestion.options">
 
                         <div class="col-md-6 question-option-empty" ng-class="option.score > 0 ? 'question-correct-option' : ''">
-                            <input id="weightedOptionText" type="text" focus-on="opt{{option.id}}" class="question-option-input" ng-model="option.option.option"
-                                ng-change="$ctrl.selectIfDefault(option.option, $event)" required="true" />
+                            <input id="weightedOptionText" type="text" focus-on="opt{{option.id}}" class="question-option-input"
+                                ng-model="option.option.option" ng-change="$ctrl.selectIfDefault(option.option, $event)"
+                                required="true" />
                         </div>
                         <div class="col-md-2 question-option-empty-radio" ng-class="option.score > 0 ? 'question-correct-option-radio' : ''">
-                            <input fixed-precision id="optionScore" name="maxScore" class="question-option-input points" type="number" step="1" ng-model="option.score"
-                                required="true" ng-disabled="$ctrl.lotteryOn" />
+                            <input fixed-precision id="optionScore" name="maxScore" class="question-option-input points"
+                                type="number" ng-model="option.score" required="true" ng-disabled="$ctrl.lotteryOn" />
                         </div>
                         <div class="col-md-1 question-option-trash pointer" ng-hide="$ctrl.lotteryOn" ng-click="$ctrl.removeOption(option)">
                             <i class="fa fa-trash-o fa-fw" title="{{'sitnet_remove' | translate}}"></i>
@@ -188,7 +191,8 @@
                     </div>
                     <div class="col-md-12">
                         <div class="col-md-6">&nbsp;</div>
-                        <div class="col-md-2 question-option-title">{{'sitnet_max_score' | translate | uppercase}}: {{$ctrl.calculateMaxPoints()}}
+                        <div class="col-md-2 question-option-title">{{'sitnet_max_score' | translate | uppercase}}:
+                            {{ $ctrl.calculateMaxPoints() }}
                         </div>
                     </div>
                 </div>
@@ -197,12 +201,14 @@
                 <div ng-if="$ctrl.question.type === 'MultipleChoiceQuestion'" ng-repeat="option in $ctrl.examQuestion.options">
                     <div class="col-md-12">
                         <div class="col-md-6 question-option-empty" ng-class="{'question-correct-option':option.option.correctOption}">
-                            <input id="optionText" type="text" focus-on="opt{{option.id}}" class="make-inline question-option-input radiobut" ng-model="option.option.option"
-                                ng-click="$ctrl.selectIfDefault(option.option.option, $event)" required="true" />
+                            <input id="optionText" type="text" focus-on="opt{{option.id}}" class="make-inline question-option-input radiobut"
+                                ng-model="option.option.option" ng-click="$ctrl.selectIfDefault(option.option.option, $event)"
+                                required="true" />
                         </div>
                         <div class="col-md-2 question-option-empty-radio" ng-class="{'question-correct-option-radio':option.option.correctOption}">
-                            <input name="correctOption" type="radio" ng-model="option.option.correctOption" ng-value="true" ng-click="$ctrl.correctAnswerToggled(option)"
-                                ng-disabled="$ctrl.optionDisabled(option)" class="make-inline question-option-radio">
+                            <input name="correctOption" type="radio" ng-model="option.option.correctOption" ng-value="true"
+                                ng-click="$ctrl.correctAnswerToggled(option)" ng-disabled="$ctrl.optionDisabled(option)"
+                                class="make-inline question-option-radio">
                         </div>
 
                         <div ng-hide="$ctrl.lotteryOn" ng-click="$ctrl.removeOption(option)" class="col-md-1 question-option-trash">
@@ -227,8 +233,8 @@
                         {{'sitnet_evaluation_type' | translate}}
                     </div>
                     <div class="col-md-9">
-                        <select id="evaluationType" class="form-control wdt240" ng-model="$ctrl.examQuestion.evaluationType" ng-change="$ctrl.updateEvaluationType()"
-                            ng-required="$ctrl.question.type == 'EssayQuestion'">
+                        <select id="evaluationType" class="form-control wdt240" ng-model="$ctrl.examQuestion.evaluationType"
+                            ng-change="$ctrl.updateEvaluationType()" ng-required="$ctrl.question.type == 'EssayQuestion'">
                             <option value="Points">{{ 'sitnet_word_points' | translate }}</option>
                             <option value="Selection">{{ 'sitnet_evaluation_select' | translate }}</option>
                         </select>
@@ -244,7 +250,7 @@
                         {{'sitnet_max_score' | translate}}
                     </div>
                     <div class="col-md-9">
-                        <input id="maxScore" name="maxScore" type="number" class="form-control wdt100" ng-model="$ctrl.examQuestion.maxScore" step="1"
+                        <input id="maxScore" name="maxScore" type="number" class="form-control wdt100" ng-model="$ctrl.examQuestion.maxScore"
                             min="0" max="1000" fixed-precision required ng-disabled="$ctrl.lotteryOn" />
                     </div>
                 </div>
@@ -260,13 +266,13 @@
                     <div class="col-md-3 exam-basic-title padl0">{{'sitnet_question_owners' | translate}}
                         <sup>
                             <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_question_owners_description' | translate}}"
-                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                            />
+                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
                         </sup>
                     </div>
                     <div class="col-md-9">
                         <ul class="list-inline mart10 padl10">
-                            <li ng-repeat="user in $ctrl.question.questionOwners">{{user.firstName }} {{ user.lastName }}
+                            <li ng-repeat="user in $ctrl.question.questionOwners">{{user.firstName }} {{ user.lastName
+                                }}
                             </li>
                         </ul>
                     </div>
@@ -279,8 +285,7 @@
                         {{ 'sitnet_question_attachment' | translate}}
                         <sup>
                             <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_attachment_description' | translate}}"
-                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                            />
+                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
                         </sup>
                     </div>
 
@@ -300,8 +305,8 @@
                                     ({{ $ctrl.getFileSize() }})</small>
                             </span>
                             <span class="pointer remove-attachment" ng-click="$ctrl.removeQuestionAttachment()">
-                                <img src="Images/icon_remove.svg" alt="{{'sitnet_remove_attachment' | translate }}" onerror="this.onerror=null;this.src='Images/icon_remove.png';"
-                                />
+                                <img src="Images/icon_remove.svg" alt="{{'sitnet_remove_attachment' | translate }}"
+                                    onerror="this.onerror=null;this.src='Images/icon_remove.png';" />
                             </span>
                         </div>
                         <div class="mart10" ng-if="$ctrl.showWarning()">
@@ -318,12 +323,13 @@
                         {{ 'sitnet_question_instruction' | translate}}
                         <sup>
                             <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_question_instruction_description' | translate}}"
-                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                            />
+                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
                         </sup>
                     </div>
                     <div class="col-md-9 padr0">
-                        <textarea id="instruction" class="form-control" rows="3" ng-model="$ctrl.examQuestion.answerInstructions" placeholder="{{'sitnet_question_instruction' | translate}}">
+                        <textarea id="instruction" class="form-control" rows="3" ng-model="$ctrl.examQuestion.answerInstructions"
+                            placeholder="{{'sitnet_question_instruction' | translate}}">
+
                         </textarea>
                     </div>
                 </div>
@@ -335,12 +341,13 @@
                         {{ 'sitnet_exam_evaluation_criteria' | translate}}
                         <sup>
                             <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_question_evaluation_criteria_description' | translate}}"
-                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                            />
+                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
                         </sup>
                     </div>
                     <div class="col-md-9 padr0">
-                        <textarea id="evaluationCriteria" class="form-control" rows="3" ng-model="$ctrl.examQuestion.evaluationCriteria" placeholder="{{'sitnet_exam_evaluation_criteria' | translate}}">
+                        <textarea id="evaluationCriteria" class="form-control" rows="3" ng-model="$ctrl.examQuestion.evaluationCriteria"
+                            placeholder="{{'sitnet_exam_evaluation_criteria' | translate}}">
+
                         </textarea>
                     </div>
                 </div>
@@ -352,8 +359,7 @@
                         {{ 'sitnet_added_to_categories' | translate}}
                         <sup>
                             <img popover-placement="right" popover-trigger="'mouseenter'" uib-popover="{{'sitnet_question_tag_question_description' | translate}}"
-                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';"
-                            />
+                                src="Images/icon_tooltip.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_tooltip.png';" />
                         </sup>
                     </div>
                     <div class="col-md-9 padr0">

--- a/app/frontend/src/review/assessment/assessment.service.js
+++ b/app/frontend/src/review/assessment/assessment.service.js
@@ -195,7 +195,7 @@ angular.module('app.review')
 
             self.saveEssayScore = function (question, examId, examRef, rev) {
                 if (!question.essayAnswer || isNaN(question.essayAnswer.evaluatedScore)) {
-                    return $q.reject();
+                    return $q.reject({ data: 'sitnet_error_score_input' });
                 }
                 const url = examId && examRef ? `/integration/iop/reviews/${examId}/${examRef}/question/${question.id}` :
                     `/app/review/examquestion/${question.id}/score`;

--- a/app/frontend/src/review/assessment/questions/essayQuestion.component.js
+++ b/app/frontend/src/review/assessment/questions/essayQuestion.component.js
@@ -54,8 +54,8 @@ angular.module('app.review')
                         .then(function (resp) {
                             toast.info($translate.instant('sitnet_graded'));
                             vm.onScore({ revision: resp.data ? resp.data.rev : undefined });
-                        }, function (error) {
-                            toast.error(error.data);
+                        }).catch(function (error) {
+                            toast.error($translate.instant(error.data));
                         });
                 };
 

--- a/app/frontend/src/review/assessment/questions/essayQuestion.template.html
+++ b/app/frontend/src/review/assessment/questions/essayQuestion.template.html
@@ -8,9 +8,9 @@
                 <!--chevron -->
                 <a class="pull-right" ng-click="$ctrl.sectionQuestion.reviewExpanded = !$ctrl.sectionQuestion.reviewExpanded">
                     <img ng-show="!$ctrl.sectionQuestion.reviewExpanded" src="Images/icon_list_show_right.svg" alt="exam"
-                         onerror="this.onerror=null;this.src='Images/icon_list_show_right.png'" />
+                        onerror="this.onerror=null;this.src='Images/icon_list_show_right.png'" />
                     <img ng-show="$ctrl.sectionQuestion.reviewExpanded" src="Images/icon_list_show_down.svg" alt="exam"
-                         onerror="this.onerror=null;this.src='Images/icon_list_show_down.png'" />
+                        onerror="this.onerror=null;this.src='Images/icon_list_show_down.png'" />
                 </a>
                 <!-- question title -->
                 <div class="review-question-title marr20" mathjax ng-bind-html="$ctrl.displayQuestionText()"></div>
@@ -18,21 +18,18 @@
             </div>
 
             <!-- question attachment -->
-            <div ng-show="$ctrl.sectionQuestion.reviewExpanded && $ctrl.sectionQuestion.question.attachment"
-                 class="padl0 mart20 marb20 notice-text">
-                    {{ 'sitnet_question_attachment' | translate}}:
-                    <a class="pointer" ng-click="$ctrl.downloadQuestionAttachment()">
-                        {{$ctrl.sectionQuestion.question.attachment.fileName}}
-                    </a>
+            <div ng-show="$ctrl.sectionQuestion.reviewExpanded && $ctrl.sectionQuestion.question.attachment" class="padl0 mart20 marb20 notice-text">
+                {{ 'sitnet_question_attachment' | translate}}:
+                <a class="pointer" ng-click="$ctrl.downloadQuestionAttachment()">
+                    {{$ctrl.sectionQuestion.question.attachment.fileName}}
+                </a>
             </div>
 
             <!-- question instructions -->
-            <div ng-show="$ctrl.sectionQuestion.reviewExpanded && $ctrl.sectionQuestion.answerInstructions"
-                 class="padl0 mart20 marb20 notice-text">
-                <img src="Images/icon_info.svg" alt="exam"
-                     onerror="this.onerror=null;this.src='Images/icon_info.png'" />
-                    <span class="padl10">{{ 'sitnet_instructions' | translate}}:</span>
-                    <span ng-bind-html="$ctrl.sectionQuestion.answerInstructions"/>
+            <div ng-show="$ctrl.sectionQuestion.reviewExpanded && $ctrl.sectionQuestion.answerInstructions" class="padl0 mart20 marb20 notice-text">
+                <img src="Images/icon_info.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_info.png'" />
+                <span class="padl10">{{ 'sitnet_instructions' | translate}}:</span>
+                <span ng-bind-html="$ctrl.sectionQuestion.answerInstructions" />
             </div>
 
             <!-- answer -->
@@ -48,30 +45,25 @@
             </div>
 
             <!-- answer attachment -->
-            <div ng-show="$ctrl.sectionQuestion.reviewExpanded && $ctrl.sectionQuestion.essayAnswer.attachment"
-                 class="padl0 mart20 marb30">
-                <a class="pointer green_button left-floater-for-section"
-                   ng-click="$ctrl.downloadQuestionAnswerAttachment()">
+            <div ng-show="$ctrl.sectionQuestion.reviewExpanded && $ctrl.sectionQuestion.essayAnswer.attachment" class="padl0 mart20 marb30">
+                <a class="pointer green_button left-floater-for-section" ng-click="$ctrl.downloadQuestionAnswerAttachment()">
                     {{ 'sitnet_download_answer_attachment' | translate}}
-                    <img src="Images/icon_attachment.svg" alt="exam"
-                         onerror="this.onerror=null;this.src='Images/icon_attachment.png'" />
+                    <img src="Images/icon_attachment.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_attachment.png'" />
                 </a>
                 <div class="attachment-name">{{$ctrl.sectionQuestion.essayAnswer.attachment.fileName | uppercase}}</div>
             </div>
 
 
             <!-- question evaluation criteria -->
-            <div ng-show="$ctrl.sectionQuestion.reviewExpanded && $ctrl.sectionQuestion.evaluationCriteria"
-                 class="padl0 mart20">
+            <div ng-show="$ctrl.sectionQuestion.reviewExpanded && $ctrl.sectionQuestion.evaluationCriteria" class="padl0 mart20">
                 <div class="points-title">
                     <span>{{'sitnet_exam_evaluation_criteria' | translate | uppercase }}</span>
                 </div>
-                <span ng-bind-html="$ctrl.sectionQuestion.evaluationCriteria"/>
+                <span ng-bind-html="$ctrl.sectionQuestion.evaluationCriteria" />
             </div>
 
             <!-- grade -->
-            <div ng-show="$ctrl.sectionQuestion.reviewExpanded && $ctrl.exam.executionType.type !== 'MATURITY'"
-                 class="make-inline padr30 mart20">
+            <div ng-show="$ctrl.sectionQuestion.reviewExpanded && $ctrl.exam.executionType.type !== 'MATURITY'" class="make-inline padr30 mart20">
                 <div class="points-title">
                     <span ng-show="$ctrl.sectionQuestion.evaluationType === 'Points'">{{
                         'sitnet_word_points' | translate | uppercase }}&nbsp;
@@ -84,21 +76,18 @@
                 <div>
                     <span ng-if="$ctrl.sectionQuestion.evaluationType === 'Points'">
                         <form name="essayPoints">
-                            <input id="score" name="score" type="number" class="form-control"
-                                   ng-model="$ctrl.sectionQuestion.essayAnswer.evaluatedScore" step="1"
-                                   ui-blur="$ctrl.insertEssayScore()"
-                                   onclick="this.focus()"
-                                   ng-disabled="!$ctrl.isScorable"
-                                   min="0" max="{{$ctrl.sectionQuestion.maxScore}}" />
-                                <small ng-show="essayPoints.$invalid" class="alert-danger">
-                                    <i class="fa fa-exclamation-circle"></i>&nbsp;{{ 'sitnet_error_score_input' | translate }}
-                                </small>
+                            <input id="score" name="score" type="number" class="form-control" ng-model="$ctrl.sectionQuestion.essayAnswer.evaluatedScore"
+                                ui-blur="$ctrl.insertEssayScore()" onclick="this.focus()" ng-disabled="!$ctrl.isScorable"
+                                min="0" max="{{$ctrl.sectionQuestion.maxScore}}" />
+                            <small ng-show="essayPoints.$invalid" class="alert-danger">
+                                <i class="fa fa-exclamation-circle"></i>&nbsp;{{ 'sitnet_error_score_input' | translate
+                                }}
+                            </small>
                         </form>
                     </span>
                     <span ng-if="$ctrl.sectionQuestion.evaluationType === 'Selection'">
                         <select class="form-control" ng-model="$ctrl.sectionQuestion.essayAnswer.evaluatedScore"
-                                ng-change="$ctrl.insertEssayScore()"
-                                ng-disabled="!$ctrl.isScorable">
+                            ng-change="$ctrl.insertEssayScore()" ng-disabled="!$ctrl.isScorable">
                             <option value="1" ng-selected="$ctrl.sectionQuestion.essayAnswer.evaluatedScore == 1">
                                 {{ 'sitnet_approved' | translate }}
                             </option>
@@ -112,17 +101,17 @@
             <div class="make-inline notice-text">
                 <!-- answer length & recommended length-->
                 <div ng-show="$ctrl.sectionQuestion.reviewExpanded">
-                        <span>{{ 'sitnet_answer_length' | translate}}:</span>
-                        {{ $ctrl.getWordCount() }} {{'sitnet_words' | translate }},
-                        {{ 'sitnet_approximately' | translate }}
-                        {{ $ctrl.getCharacterCount() }} {{'sitnet_characters' | translate
-                        }}
+                    <span>{{ 'sitnet_answer_length' | translate}}:</span>
+                    {{ $ctrl.getWordCount() }} {{'sitnet_words' | translate }},
+                    {{ 'sitnet_approximately' | translate }}
+                    {{ $ctrl.getCharacterCount() }} {{'sitnet_characters' | translate
+                    }}
                 </div>
                 <div ng-show="$ctrl.sectionQuestion.reviewExpanded && $ctrl.sectionQuestion.expectedWordCount">
-                        <span>{{ 'sitnet_essay_length_recommendation' | translate}}:</span>
-                        {{ $ctrl.sectionQuestion.expectedWordCount }}
-                        ({{ 'sitnet_approximately' | translate}} {{$ctrl.sectionQuestion.expectedWordCount * 8}}
-                        {{'sitnet_characters' | translate}})
+                    <span>{{ 'sitnet_essay_length_recommendation' | translate}}:</span>
+                    {{ $ctrl.sectionQuestion.expectedWordCount }}
+                    ({{ 'sitnet_approximately' | translate}} {{$ctrl.sectionQuestion.expectedWordCount * 8}}
+                    {{'sitnet_characters' | translate}})
                 </div>
             </div>
         </div>

--- a/app/frontend/src/review/questions/assessment/essayAnswer.template.html
+++ b/app/frontend/src/review/questions/assessment/essayAnswer.template.html
@@ -1,8 +1,8 @@
 <div class="essay-answer-wrapper">
     <div class="detail-row" ng-if="$ctrl.answer.question.question !== $ctrl.answer.question.parent.question">
-       <span class="col-md-12 alert alert-warning essay-answer-warning" role="alert">
-           <i class="fa fa-exclamation-triangle fa-lg"></i>&nbsp;{{'sitnet_question_differs' | translate}}
-       </span>
+        <span class="col-md-12 alert alert-warning essay-answer-warning" role="alert">
+            <i class="fa fa-exclamation-triangle fa-lg"></i>&nbsp;{{'sitnet_question_differs' | translate}}
+        </span>
     </div>
     <div class="main-row">
         <div class="col-md-12 marl5">
@@ -15,17 +15,15 @@
                 <strong>
                     {{$ctrl.name}}
                     <span ng-if="$ctrl.answer.examSection.exam.creator.userIdentifier">
-                    ({{$ctrl.answer.examSection.exam.creator.userIdentifier}})
-                </span>
+                        ({{$ctrl.answer.examSection.exam.creator.userIdentifier}})
+                    </span>
                 </strong>
             </a>
         </div>
         <div class="col-md-2 essay-answer-item">
             <a class="pull-right" ng-click="$ctrl.answer.expanded = !$ctrl.answer.expanded" class="pointer-hand">
-                <img ng-show="!$ctrl.answer.expanded" src="Images/icon_list_show_right.svg"
-                     alt="exam" onerror="this.onerror=null;this.src='Images/icon_list_show_right.png';"/>
-                <img ng-show="$ctrl.answer.expanded" src="Images/icon_list_show_down.svg"
-                     alt="exam" onerror="this.onerror=null;this.src='Images/icon_list_show_down.png';"/>
+                <img ng-show="!$ctrl.answer.expanded" src="Images/icon_list_show_right.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_list_show_right.png';" />
+                <img ng-show="$ctrl.answer.expanded" src="Images/icon_list_show_down.svg" alt="exam" onerror="this.onerror=null;this.src='Images/icon_list_show_down.png';" />
             </a>
         </div>
     </div>
@@ -87,12 +85,8 @@
                 <div class="detail-row">
                     <div ng-if="$ctrl.answer.evaluationType === 'Points'">
                         <form name="essayPoints">
-                            <input id="score" name="score" type="number" class="form-control"
-                                   ng-model="$ctrl.answer.essayAnswer.score" step="1"
-                                   size="5"
-                                   onclick="this.focus();"
-                                   ng-disabled="!$ctrl.editable"
-                                   min="0" max="{{$ctrl.answer.maxScore}}"/>
+                            <input id="score" name="score" type="number" class="form-control" ng-model="$ctrl.answer.essayAnswer.score"
+                                size="5" onclick="this.focus();" ng-disabled="!$ctrl.editable" min="0" max="{{$ctrl.answer.maxScore}}" />
                             <small ng-show="essayPoints.$invalid" class="alert-danger">
                                 <i class="fa fa-exclamation-circle"></i>&nbsp;{{ 'sitnet_error_score_input' | translate
                                 }}
@@ -100,8 +94,7 @@
                         </form>
                     </div>
                     <div ng-if="$ctrl.answer.evaluationType === 'Selection'">
-                        <select class="form-control" ng-model="$ctrl.answer.essayAnswer.score"
-                                ng-disabled="!$ctrl.editable">
+                        <select class="form-control" ng-model="$ctrl.answer.essayAnswer.score" ng-disabled="!$ctrl.editable">
                             <option value="1" ng-selected="$ctrl.answer.essayAnswer.score === 1">
                                 {{ 'sitnet_approved' | translate }}
                             </option>
@@ -117,13 +110,11 @@
         <div class="main-row">
             <span class="col-md-12 checkbox">
                 <label>
-                    <input type="checkbox" ng-model="$ctrl.answer.selected"
-                           ng-disabled="!$ctrl.editable || !$ctrl.isAssessed()">
+                    <input type="checkbox" ng-model="$ctrl.answer.selected" ng-disabled="!$ctrl.editable || !$ctrl.isAssessed()">
                     {{$ctrl.action | translate }}
                 </label>
-                <i ng-if="$ctrl.editable && $ctrl.isAssessed() && $ctrl.answer.selected"
-                   class="marl10 pointer fa fa-lg fa-share text-success"
-                   ng-click="$ctrl.saveScore()"></i>
+                <i ng-if="$ctrl.editable && $ctrl.isAssessed() && $ctrl.answer.selected" class="marl10 pointer fa fa-lg fa-share text-success"
+                    ng-click="$ctrl.saveScore()"></i>
             </span>
         </div>
 


### PR DESCRIPTION
- Angularjs 1.6 had introduced a step directive that did not allow
  decimal number inputs if step value was an integer.
- Fix: get rid of defining step=1. Browsers appear to use 1
  automatically.