### PR TITLE
CSCEXAM-218 & CSCEXAM-219  minor fixes

### DIFF
--- a/app/backend/controllers/base/BaseController.java
+++ b/app/backend/controllers/base/BaseController.java
@@ -168,8 +168,18 @@ public class BaseController extends Controller {
                 .eq("user", user)
                 .eq("noShow", false)
                 .lt("endAt", new Date())
+                // Either a) exam id matches and exam state is published OR
+                //        b) collaborative exam id matches and exam is NULL
+                .or()
+                .and()
                 .eq("enrolment.exam.id", examId)
                 .eq("enrolment.exam.state", Exam.State.PUBLISHED)
+                .endAnd()
+                .and()
+                .eq("enrolment.collaborativeExam.id", examId)
+                .isNull("enrolment.exam")
+                .endAnd()
+                .endOr()
                 .isNull("externalReservation")
                 .findList();
         noShowHandler.handleNoShows(reservations);

--- a/app/backend/controllers/iop/collaboration/impl/CollaborativeCalendarController.java
+++ b/app/backend/controllers/iop/collaboration/impl/CollaborativeCalendarController.java
@@ -49,15 +49,6 @@ public class CollaborativeCalendarController extends CollaborationController {
             return wrapAsPromise(notFound("sitnet_error_exam_not_found"));
         }
 
-        ExamEnrolment ee = Ebean.find(ExamEnrolment.class).where()
-                .eq("collaborativeExam.id", id)
-                .isNull("exam")
-                .eq("user", getLoggedUser())
-                .findOne();
-        if (ee == null) {
-            return wrapAsPromise(notFound("sitnet_error_exam_not_found"));
-        }
-
         return downloadExam(ce).thenApplyAsync(
                 result -> {
                     if (!result.isPresent()) {

--- a/app/backend/impl/EmailComposer.java
+++ b/app/backend/impl/EmailComposer.java
@@ -84,7 +84,7 @@ public interface EmailComposer {
     /**
      * Message sent to student when he did not show up for exam.
      */
-    void composeNoShowMessage(User student, Exam exam);
+    void composeNoShowMessage(User student, String examName, String courseCode);
 
     /**
      * Message sent to teacher when language inspection is finished.

--- a/app/backend/impl/EmailComposerImpl.java
+++ b/app/backend/impl/EmailComposerImpl.java
@@ -543,13 +543,13 @@ class EmailComposerImpl implements EmailComposer {
     }
 
     @Override
-    public void composeNoShowMessage(User student, Exam exam) {
+    public void composeNoShowMessage(User student, String examName, String courseCode) {
         String templatePath = getTemplatesRoot() + "noShow.html";
         String template = readFile(templatePath, ENCODING);
         Lang lang = getLang(student);
         String subject = messaging.get(lang, "email.template.noshow.student.subject");
         String message = messaging.get(lang, "email.template.noshow.student.message",
-                exam.getName(), exam.getCourse().getCode());
+                examName, courseCode);
         Map<String, String> stringValues = new HashMap<>();
         stringValues.put("message", message);
         String content = replaceAll(template, stringValues);

--- a/app/backend/system/actors/ReservationPollerActor.java
+++ b/app/backend/system/actors/ReservationPollerActor.java
@@ -44,6 +44,7 @@ public class ReservationPollerActor extends AbstractActor {
             List<Reservation> reservations = Ebean.find(Reservation.class)
                     .fetch("enrolment")
                     .fetch("enrolment.exam")
+                    .fetch("enrolment.collaborativeExam")
                     .fetch("enrolment.externalExam")
                     .where()
                     .eq("noShow", false)

--- a/app/frontend/src/reservation/admin/removeReservationDialog.component.ts
+++ b/app/frontend/src/reservation/admin/removeReservationDialog.component.ts
@@ -31,7 +31,7 @@ export const RemoveReservationDialogComponent: angular.IComponentOptions = {
         dismiss: (_: { $value: string }) => void;
 
         reservation: { id: number };
-        message: { text: string };
+        message = { text: undefined };
 
         constructor(
             private $http: angular.IHttpService,


### PR DESCRIPTION
- loose the enrolment check when viewing exam general info as student
- check that exam has a course when determining whether grade can be
  updated
- mark also collaborative exam reservations as no-shows when
  applicable
- fix a bug in reservation removal dialog. Crashes on empty message.