### PR TITLE
CSCEXAM-235 modify Content-Disposition header format

### DIFF
--- a/app/backend/controllers/BaseAttachmentInterface.java
+++ b/app/backend/controllers/BaseAttachmentInterface.java
@@ -16,20 +16,23 @@
 
 package backend.controllers;
 
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
-import backend.util.file.ChunkMaker;
-import backend.models.Attachment;
-import backend.models.Exam;
-import backend.models.ExamSectionQuestion;
 import be.objectify.deadbolt.java.actions.Group;
 import be.objectify.deadbolt.java.actions.Pattern;
 import be.objectify.deadbolt.java.actions.Restrict;
 import play.mvc.Result;
 
-import java.util.Base64;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import backend.models.Attachment;
+import backend.models.Exam;
+import backend.models.ExamSectionQuestion;
+import backend.util.file.ChunkMaker;
 
 import static play.mvc.Results.ok;
 
@@ -68,16 +71,22 @@ public interface BaseAttachmentInterface<T> {
     CompletionStage<Result> deleteStatementAttachment(T id);
 
     default CompletionStage<Result> serveAsBase64Stream(Attachment attachment, Source<ByteString, ?> source) {
-        return serveAsBase64Stream(attachment.getMimeType(), attachment.getFileName(), source);
+        try {
+            return serveAsBase64Stream(attachment.getMimeType(), attachment.getFileName(), source);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    default CompletionStage<Result> serveAsBase64Stream(String mimeType, String fileName, Source<ByteString, ?> source) {
+    default CompletionStage<Result> serveAsBase64Stream(String mimeType, String fileName, Source<ByteString, ?> source) throws IOException  {
+        String escapedName = URLEncoder.encode(fileName, "UTF-8");
         return CompletableFuture.supplyAsync(() -> ok().chunked(source.via(new ChunkMaker(3 * 1024))
                 .map(byteString -> {
                     final byte[] encoded = Base64.getEncoder().encode(byteString.toArray());
                     return ByteString.fromArray(encoded);
                 })).as(mimeType)
-                .withHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\""));
+                .withHeader("Content-Disposition", "attachment; filename*=UTF-8''\"" + escapedName + "\""));
+
     }
 
     default ExamSectionQuestion getExamSectionQuestion(Long qid, Exam exam) {

--- a/app/backend/controllers/iop/collaboration/api/CollaborativeAttachmentInterface.java
+++ b/app/backend/controllers/iop/collaboration/api/CollaborativeAttachmentInterface.java
@@ -17,6 +17,7 @@
 package backend.controllers.iop.collaboration.api;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -30,17 +31,6 @@ import akka.stream.IOResult;
 import akka.stream.javadsl.FileIO;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
-
-import backend.controllers.BaseAttachmentInterface;
-import backend.models.Attachment;
-import backend.models.Comment;
-import backend.models.Exam;
-import backend.models.ExamSectionQuestion;
-import backend.models.User;
-import backend.models.api.AttachmentContainer;
-import backend.models.questions.EssayAnswer;
-import backend.util.AppUtil;
-import backend.util.config.ConfigUtil;
 import be.objectify.deadbolt.java.actions.Group;
 import be.objectify.deadbolt.java.actions.Restrict;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -54,6 +44,17 @@ import play.libs.ws.WSResponse;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
+
+import backend.controllers.BaseAttachmentInterface;
+import backend.models.Attachment;
+import backend.models.Comment;
+import backend.models.Exam;
+import backend.models.ExamSectionQuestion;
+import backend.models.User;
+import backend.models.api.AttachmentContainer;
+import backend.models.questions.EssayAnswer;
+import backend.util.AppUtil;
+import backend.util.config.ConfigUtil;
 
 import static play.mvc.Controller.request;
 import static play.mvc.Http.Status.NOT_FOUND;
@@ -435,7 +436,11 @@ public interface CollaborativeAttachmentInterface<T, U> extends BaseAttachmentIn
             if (response.getStatus() != 200) {
                 return CompletableFuture.supplyAsync(() -> Results.status(response.getStatus()));
             }
-            return serveAsBase64Stream(mimeType, fileName, response.getBodyAsSource());
+            try {
+                return serveAsBase64Stream(mimeType, fileName, response.getBodyAsSource());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         });
     }
 

--- a/test/controllers/iop/BaseCollaborativeAttachmentControllerTest.java
+++ b/test/controllers/iop/BaseCollaborativeAttachmentControllerTest.java
@@ -16,15 +16,16 @@
 
 package controllers.iop;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import javax.servlet.MultipartConfigElement;
+
 import akka.actor.ActorSystem;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
-import backend.models.Attachment;
-import backend.models.Exam;
-import backend.models.ExamExecutionType;
-import backend.models.ExamSectionQuestion;
-import backend.models.questions.EssayAnswer;
-import backend.models.questions.Question;
 import base.IntegrationTestCase;
 import helpers.AttachmentServlet;
 import helpers.ExamServlet;
@@ -43,12 +44,12 @@ import play.Logger;
 import play.mvc.Result;
 import play.test.Helpers;
 
-import javax.servlet.MultipartConfigElement;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Base64;
+import backend.models.Attachment;
+import backend.models.Exam;
+import backend.models.ExamExecutionType;
+import backend.models.ExamSectionQuestion;
+import backend.models.questions.EssayAnswer;
+import backend.models.questions.Question;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -124,7 +125,7 @@ public abstract class BaseCollaborativeAttachmentControllerTest<T> extends Integ
 
     void assertDownloadResult(Result result) throws IOException {
         assertThat(result.header("Content-Disposition").orElse(null))
-                .isEqualTo("attachment; filename=\"test_image.png\"");
+                .isEqualTo("attachment; filename*=UTF-8''\"test_image.png\"");
         ActorSystem actorSystem = ActorSystem.create("TestSystem");
         Materializer mat = ActorMaterializer.create(actorSystem);
         final String content = Helpers.contentAsString(result, mat);


### PR DESCRIPTION
- see RFC5987
- filename part needs URL-encoding
- specify UTF-8 as charset used for filename