### PR TITLE
CSCEXAM-507: Correctly escape backlashes on correct cloze test answer

### DIFF
--- a/app/backend/models/questions/ClozeTestAnswer.java
+++ b/app/backend/models/questions/ClozeTestAnswer.java
@@ -211,10 +211,11 @@ public class ClozeTestAnswer extends GeneratedIdentityModel {
         // escape sequence until restoring them in the regex.
         final String ESC = "__!ESC__";
         String regex = escapeSpecialRegexChars(correctAnswer)
-                .replace("\\*", ESC)
+        // Also backlashes will be escaped on escapeSpecialRegexChars call, therefore '\\*' pattern needs to be replaced
+                .replaceAll("\\Q\\\\*\\E", ESC)
                 .replace("*", ".*")
                 .replace(ESC, "\\*")
-                .replace("\\|", ESC);
+                .replaceAll("\\Q\\\\|\\E", ESC);
 
         if (regex.contains("|")) {
             regex = String.format("(%s)", regex);


### PR DESCRIPTION
Backlashes in cloze answers are escaped, resulting in regex strings like '\\*' if the user has already used a backlash to escape special characters. Previously these patterns weren't correctly replaced during formatting and matching.