### PR TITLE
CSCEXAM-515: Enable claim choice question on collaborative and external exams and some fixes

### DIFF
--- a/app/backend/controllers/StudentActionsController.java
+++ b/app/backend/controllers/StudentActionsController.java
@@ -49,7 +49,6 @@ import backend.models.ExamParticipation;
 import backend.models.ExaminationEventConfiguration;
 import backend.models.User;
 import backend.models.json.CollaborativeExam;
-import backend.models.questions.Question;
 import backend.models.sections.ExamSection;
 import backend.sanitizers.Attrs;
 import backend.security.Authenticated;
@@ -315,21 +314,6 @@ public class StudentActionsController extends CollaborationController {
                 .findOne();
         if (exam == null) {
             return notFound("sitnet_error_exam_not_found");
-        }
-
-        /* Temporary solution to check if external exam should be disabled */
-        Set<ExamSection> sections = Ebean.find(ExamSection.class)
-                .fetch("sectionQuestions.question", "type")
-                .where()
-                .eq("exam", exam)
-                .findSet();
-
-        if(sections.size() > 0) {
-            boolean hasClaimChoiceQuestion = sections.stream()
-                    .flatMap(es -> es.getSectionQuestions().stream())
-                    .filter(esq -> esq.getQuestion() != null)
-                    .anyMatch(esq -> esq.getQuestion().getType() == Question.Type.ClaimChoiceQuestion);
-            exam.setExternalReservationDisabled(hasClaimChoiceQuestion);
         }
 
         return ok(exam);

--- a/app/backend/controllers/iop/transfer/impl/ExternalExamController.java
+++ b/app/backend/controllers/iop/transfer/impl/ExternalExamController.java
@@ -73,6 +73,7 @@ import backend.models.ExamEnrolment;
 import backend.models.ExamInspection;
 import backend.models.ExamParticipation;
 import backend.models.GeneralSettings;
+import backend.models.questions.Question;
 import backend.models.Reservation;
 import backend.models.User;
 import backend.models.json.ExternalExam;
@@ -218,7 +219,7 @@ public class ExternalExamController extends BaseController implements ExternalEx
                 "examType(id, type), creditType(id, type), gradeScale(id, displayName, grades(id, name)), " +
                 "examSections(id, name, sequenceNumber, description, lotteryOn, lotteryItemCount," + // ((
                 "sectionQuestions(id, sequenceNumber, maxScore, answerInstructions, evaluationCriteria, expectedWordCount, evaluationType, derivedMaxScore, " + // (((
-                "question(id, type, question, attachment(*), options(id, option, correctOption, defaultScore)), " +
+                "question(id, type, question, attachment(*), options(id, option, correctOption, defaultScore, claimChoiceType)), " +
                 "options(id, answered, score, option(id, option)), " +
                 "essayAnswer(id, answer, objectVersion, attachment(*)), " +
                 "clozeTestAnswer(id, question, answer, objectVersion)" +
@@ -296,6 +297,10 @@ public class ExternalExamController extends BaseController implements ExternalEx
             // Shuffle multi-choice options
             document.getExamSections().stream()
                     .flatMap(es -> es.getSectionQuestions().stream()).forEach(esq -> {
+                Question.Type questionType = Optional.ofNullable(esq.getQuestion()).map(Question::getType).orElseGet(null);
+                if(questionType == Question.Type.ClaimChoiceQuestion) {
+                    return;
+                }
                 List<ExamSectionQuestionOption> shuffled = new ArrayList<>(esq.getOptions());
                 Collections.shuffle(shuffled);
                 esq.setOptions(new HashSet<>(shuffled));

--- a/app/backend/models/Exam.java
+++ b/app/backend/models/Exam.java
@@ -283,14 +283,6 @@ public class Exam extends OwnedModel implements Comparable<Exam>, AttachmentCont
     @Transient
     private String externalRef;
 
-    /* Temporary field, used to block external exam reservations on the front end */
-    @Transient
-    private boolean externalReservationDisabled;
-
-    public void setExternalReservationDisabled(boolean externalReservationDisabled) {
-        this.externalReservationDisabled = externalReservationDisabled;
-    }
-
     private double toFixed(double val) {
         return Double.valueOf(df.format(val));
     }

--- a/app/backend/models/sections/ExamSectionQuestion.java
+++ b/app/backend/models/sections/ExamSectionQuestion.java
@@ -228,15 +228,13 @@ public class ExamSectionQuestion extends OwnedModel implements Comparable<ExamSe
         Question blueprint = question.copy(optionMap, true);
         blueprint.setParent(question);
         blueprint.save();
-        optionMap.forEach((k, optionCopy) -> {
-            optionCopy.setQuestion(blueprint);
-            optionCopy.save();
-            Optional<ExamSectionQuestionOption> esqoo = options.stream()
-                    .filter(o -> o.getOption().getId().equals(k))
-                    .findFirst();
-            if (esqoo.isPresent()) {
-                ExamSectionQuestionOption esqo = esqoo.get();
-                ExamSectionQuestionOption esqoCopy = esqo.copyWithAnswer();
+        options.forEach(option -> {
+            Optional<MultipleChoiceOption> parentOption = Optional.ofNullable(option.getOption()).filter(opt -> opt.getId() != null);
+            if(parentOption.isPresent()) {
+                MultipleChoiceOption optionCopy = optionMap.get(parentOption.get().getId());
+                optionCopy.setQuestion(blueprint);
+                optionCopy.save();
+                ExamSectionQuestionOption esqoCopy = option.copyWithAnswer();
                 esqoCopy.setOption(optionCopy);
                 esqCopy.getOptions().add(esqoCopy);
             } else {
@@ -244,6 +242,7 @@ public class ExamSectionQuestion extends OwnedModel implements Comparable<ExamSe
                 throw new RuntimeException();
             }
         });
+
         esqCopy.setQuestion(blueprint);
         // Essay Answer
         if (essayAnswer != null) {

--- a/app/frontend/src/calendar/calendar.component.ts
+++ b/app/frontend/src/calendar/calendar.component.ts
@@ -31,7 +31,6 @@ interface ExamInfo {
     examActiveStartDate: number;
     examActiveEndDate: number;
     examSections: SelectableSection[];
-    externalReservationDisabled?: boolean;
 }
 
 interface AvailableSlot extends Slot {

--- a/app/frontend/src/calendar/calendar.template.html
+++ b/app/frontend/src/calendar/calendar.template.html
@@ -220,7 +220,7 @@
                     <button
                         class="btn btn-sm btn-success btn-link"
                         ng-click="$ctrl.makeExternalReservation()"
-                        ng-if="$ctrl.isInteroperable && !$ctrl.isCollaborative && !$ctrl.isExternal && !$ctrl.hasOptionalSections() && !$ctrl.examInfo.externalReservationDisabled"
+                        ng-if="$ctrl.isInteroperable && !$ctrl.isCollaborative && !$ctrl.isExternal && !$ctrl.hasOptionalSections()"
                     >
                         {{'sitnet_external_reservation' | translate }}&nbsp;
                         <i class="fa fa-angle-double-right"></i>

--- a/app/frontend/src/examination/question/examinationMultiChoiceQuestion.component.js
+++ b/app/frontend/src/examination/question/examinationMultiChoiceQuestion.component.js
@@ -38,6 +38,7 @@ angular.module('app.examination').component('examinationMultiChoiceQuestion', {
         examHash: '<',
         isPreview: '<',
         isCollaborative: '<',
+        orderOptions: '<',
     },
     controller: [
         'Examination',
@@ -45,9 +46,9 @@ angular.module('app.examination').component('examinationMultiChoiceQuestion', {
             const vm = this;
 
             vm.$onInit = function() {
-                if (vm.sq.question.type === 'ClaimChoiceQuestion' && !vm.isCollaborative) {
+                if (vm.sq.question.type === 'ClaimChoiceQuestion' && !vm.isCollaborative && vm.orderOptions) {
                     vm.sq.options.sort((a, b) => a.option.id - b.option.id);
-                } else {
+                } else if (vm.orderOptions) {
                     vm.sq.options.sort((a, b) => a.id - b.id);
                 }
 

--- a/app/frontend/src/examination/question/examinationQuestion.template.html
+++ b/app/frontend/src/examination/question/examinationQuestion.template.html
@@ -108,6 +108,7 @@
                 exam-hash="$ctrl.exam.hash"
                 is-preview="$ctrl.isPreview"
                 is-collaborative="$ctrl.isCollaborative"
+                order-options="!$ctrl.exam.external"
             >
             </examination-multi-choice-question>
 
@@ -117,6 +118,7 @@
                 exam-hash="$ctrl.exam.hash"
                 is-preview="$ctrl.isPreview"
                 is-collaborative="$ctrl.isCollaborative"
+                order-options="!$ctrl.exam.external"
             >
             </examination-multi-choice-question>
 
@@ -125,6 +127,7 @@
                 sq="$ctrl.sq"
                 exam-hash="$ctrl.exam.hash"
                 is-preview="$ctrl.isPreview"
+                order-options="!$ctrl.exam.external"
             >
             </examination-weighted-multi-choice-question>
         </div>

--- a/app/frontend/src/examination/question/examinationWeightedMultiChoiceQuestion.component.js
+++ b/app/frontend/src/examination/question/examinationWeightedMultiChoiceQuestion.component.js
@@ -20,7 +20,7 @@ angular.module('app.examination').component('examinationWeightedMultiChoiceQuest
         '<div class="bottom-padding-2">' +
         '    <fieldset>' +
         '        <legend style="visibility: hidden;">answer options for multiple choice question</legend>' +
-        '        <div ng-repeat="sqo in $ctrl.sq.options | orderBy: \'id\'" class="exam-answer-options">' +
+        '        <div ng-repeat="sqo in $ctrl.sq.options" class="exam-answer-options">' +
         '            <input type="checkbox" aria-label="option" name="selectedOption"' +
         '                ng-checked="sqo.answered" ng-model="sqo.answered"' +
         '                ng-change="$ctrl.saveOption()"/>' +
@@ -35,11 +35,18 @@ angular.module('app.examination').component('examinationWeightedMultiChoiceQuest
         sq: '<',
         examHash: '<',
         isPreview: '<',
+        orderOptions: '<',
     },
     controller: [
         'Examination',
         function(Examination) {
             const vm = this;
+
+            vm.$onInit = function() {
+                if (vm.orderOptions) {
+                    vm.sq.options.sort((a, b) => a.id - b.id);
+                }
+            };
 
             vm.saveOption = function() {
                 Examination.saveOption(vm.examHash, vm.sq, vm.isPreview);

--- a/app/frontend/src/question/basequestion/questionBody.component.js
+++ b/app/frontend/src/question/basequestion/questionBody.component.js
@@ -62,19 +62,13 @@ angular.module('app.question').component('questionBody', {
             };
 
             vm.$onInit = function() {
-                const collaborativeQuestionTypes = [
+                vm.questionTypes = [
                     { type: 'essay', name: 'sitnet_toolbar_essay_question' },
                     { type: 'cloze', name: 'sitnet_toolbar_cloze_test_question' },
                     { type: 'multichoice', name: 'sitnet_toolbar_multiplechoice_question' },
                     { type: 'weighted', name: 'sitnet_toolbar_weighted_multiplechoice_question' },
-                ];
-
-                const basicQuestionTypes = [
-                    ...collaborativeQuestionTypes,
                     { type: 'claim', name: 'sitnet_toolbar_claim_choice_question' },
                 ];
-
-                vm.questionTypes = vm.collaborative ? collaborativeQuestionTypes : basicQuestionTypes;
 
                 init();
             };

--- a/app/frontend/src/review/assessment/questions/claimChoiceAnswer.component.js
+++ b/app/frontend/src/review/assessment/questions/claimChoiceAnswer.component.js
@@ -25,10 +25,14 @@ angular.module('app.review').component('rClaimChoiceAnswer', {
         function(Question) {
             const vm = this;
 
+            vm.$onInit = function() {
+                vm.sectionQuestion.options.sort((a, b) => a.option.id - b.option.b).reverse();
+            };
+
             vm.getSelectedOptionClass = function(examOption) {
                 const { answered = false, option = null } = examOption;
 
-                if (!answered || !(option && option.claimChoiceType)) {
+                if (!answered) {
                     return 'exam-not-answered';
                 }
 

--- a/app/frontend/src/review/assessment/questions/claimChoiceAnswer.template.html
+++ b/app/frontend/src/review/assessment/questions/claimChoiceAnswer.template.html
@@ -1,7 +1,7 @@
 <div
     class="padl15 marb10"
     ng-show="$ctrl.sectionQuestion.reviewExpanded"
-    ng-repeat="option in $ctrl.sectionQuestion.options | orderBy:'id'"
+    ng-repeat="option in $ctrl.sectionQuestion.options"
 >
     <div>
         <div ng-class="$ctrl.getSelectedOptionClass(option)">

--- a/test/base/IntegrationTestCase.java
+++ b/test/base/IntegrationTestCase.java
@@ -322,6 +322,7 @@ public class IntegrationTestCase {
             Ebean.saveAll(all.get("question-essay"));
             Ebean.saveAll(all.get("question-multiple-choice"));
             Ebean.saveAll(all.get("question-weighted-multiple-choice"));
+            Ebean.saveAll(all.get("question-claim-choice"));
             Ebean.saveAll(all.get("question-clozetest"));
             Ebean.saveAll(all.get("softwares"));
             Ebean.saveAll(all.get("courses"));

--- a/test/controllers/ExamControllerTest.java
+++ b/test/controllers/ExamControllerTest.java
@@ -125,7 +125,7 @@ public class ExamControllerTest extends IntegrationTestCase {
         assertThat(result.status()).isEqualTo(200);
         JsonNode node = Json.parse(contentAsString(result));
         assertPathsExist(node, getExamFields());
-        assertPathCounts(node, 3, getExamSectionFieldsOfExam("*"));
+        assertPathCounts(node, 4, getExamSectionFieldsOfExam("*"));
         assertPathCounts(node, 2, "softwares[*].id", "softwares[*].name");
         assertPathCounts(node, 4, "examLanguages[*].code");
 

--- a/test/controllers/ExaminationControllerTest.java
+++ b/test/controllers/ExaminationControllerTest.java
@@ -1,7 +1,9 @@
 package controllers;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import javax.mail.internet.MimeMessage;
 
 import base.IntegrationTestCase;
@@ -34,6 +36,7 @@ import backend.models.Reservation;
 import backend.models.User;
 import backend.models.questions.ClozeTestAnswer;
 import backend.models.questions.EssayAnswer;
+import backend.models.questions.MultipleChoiceOption.ClaimChoiceOptionType;
 import backend.models.questions.Question;
 import backend.models.sections.ExamSectionQuestion;
 import backend.models.sections.ExamSectionQuestionOption;
@@ -352,6 +355,31 @@ public class ExaminationControllerTest extends IntegrationTestCase {
         ExamParticipation participation = Ebean.find(ExamParticipation.class).where().eq("exam.id", studentExam.getId()).findOne();
         assertThat(participation.getStarted()).isNotNull();
         assertThat(participation.getUser().getId()).isEqualTo(user.getId());
+    }
+
+    @Test
+    @RunAsStudent
+    public void testClaimChoiceQuestionOptionOrderAndAnswerSkip() throws Exception {
+        Result result = get("/app/student/exam/" + exam.getHash());
+        JsonNode node = Json.parse(contentAsString(result));
+        Exam studentExam = deserialize(Exam.class, node);
+        ExamSectionQuestion question = Ebean.find(ExamSectionQuestion.class).where()
+                .eq("examSection.exam", studentExam)
+                .eq("question.type", Question.Type.ClaimChoiceQuestion)
+                .findList()
+                .get(0);
+        List<ExamSectionQuestionOption> options = new ArrayList<>(question.getOptions());
+
+        // Check that option order is the same as in original question, although scores have been changed for exam options
+        assertThat(options.get(0).getScore()).isEqualTo(-1);
+        assertThat(options.get(0).getOption().getClaimChoiceType()).isEqualTo(ClaimChoiceOptionType.CorrectOption);
+        assertThat(options.get(1).getScore()).isEqualTo(1);
+        assertThat(options.get(1).getOption().getClaimChoiceType()).isEqualTo(ClaimChoiceOptionType.IncorrectOption);
+        assertThat(options.get(2).getOption().getClaimChoiceType()).isEqualTo(ClaimChoiceOptionType.SkipOption);
+
+        result = request(Helpers.POST, String.format("/app/student/exam/%s/question/%d/option", studentExam.getHash(),
+                question.getId()), createMultipleChoiceAnswerData(options.get(2)));
+        assertThat(result.status()).isEqualTo(200);
     }
 
 }

--- a/test/resources/enrolment.json
+++ b/test/resources/enrolment.json
@@ -574,6 +574,122 @@
           "expectedWordCount": null,
           "answerInstructions": null,
           "evaluationCriteria": null
+        },
+        {
+          "id": 19460,
+          "created": null,
+          "creator": null,
+          "options": [
+            {
+              "id": 16003,
+              "score": 1,
+              "option": {
+                "id": 20001,
+                "option": "Tosi",
+                "defaultScore": null,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              },
+              "answered": false,
+              "objectVersion": 0
+            },
+            {
+              "id": 16002,
+              "score": -1,
+              "option": {
+                "id": 20002,
+                "option": "Epätosi",
+                "defaultScore": null,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              },
+              "answered": false,
+              "objectVersion": 0
+            },
+            {
+              "id": 16001,
+              "score": 0,
+              "option": {
+                "id": 20003,
+                "option": "En osaa sanoa",
+                "defaultScore": null,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              },
+              "answered": false,
+              "objectVersion": 0
+            }
+          ],
+          "ordinal": 3,
+          "approved": false,
+          "maxScore": null,
+          "minScore": 0.0,
+          "modified": null,
+          "modifier": null,
+          "question": {
+            "id": 253000,
+            "tags": [],
+            "type": "ClaimChoiceQuestion",
+            "state": null,
+            "parent": null,
+            "shared": false,
+            "created": null,
+            "creator": null,
+            "options": [
+              {
+                "id": 20003,
+                "option": "En osaa sanoa",
+                "defaultScore": 0,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              },
+              {
+                "id": 20002,
+                "option": "Epätosi",
+                "defaultScore": -1,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              },
+              {
+                "id": 20001,
+                "option": "Tosi",
+                "defaultScore": 1,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              }
+            ],
+            "modified": null,
+            "modifier": null,
+            "question": "<p>Suomi kuuluu Eurooppaan.</p>\n",
+            "attachment": null,
+            "objectVersion": 0,
+            "questionOwners": [],
+            "defaultMaxScore": null,
+            "maxDefaultScore": 1.0,
+            "minDefaultScore": -1.0,
+            "defaultEvaluationType": null,
+            "defaultExpectedWordCount": null,
+            "defaultAnswerInstructions": null,
+            "defaultEvaluationCriteria": null
+          },
+          "rejected": false,
+          "essayAnswer": null,
+          "assessedScore": 0.0,
+          "objectVersion": 0,
+          "evaluationType": null,
+          "sequenceNumber": 3,
+          "clozeTestAnswer": null,
+          "derivedMaxScore": null,
+          "maxAssessedScore": 0.0,
+          "expectedWordCount": null,
+          "answerInstructions": null,
+          "evaluationCriteria": null
         }
       ]
     }

--- a/test/resources/enrolment_with_lottery.json
+++ b/test/resources/enrolment_with_lottery.json
@@ -577,6 +577,122 @@
           "expectedWordCount": null,
           "answerInstructions": null,
           "evaluationCriteria": null
+        },
+        {
+          "id": 19460,
+          "created": null,
+          "creator": null,
+          "options": [
+            {
+              "id": 16003,
+              "score": 1,
+              "option": {
+                "id": 20001,
+                "option": "Tosi",
+                "defaultScore": null,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              },
+              "answered": false,
+              "objectVersion": 0
+            },
+            {
+              "id": 16002,
+              "score": -1,
+              "option": {
+                "id": 20002,
+                "option": "Epätosi",
+                "defaultScore": null,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              },
+              "answered": false,
+              "objectVersion": 0
+            },
+            {
+              "id": 16001,
+              "score": 0,
+              "option": {
+                "id": 20003,
+                "option": "En osaa sanoa",
+                "defaultScore": null,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              },
+              "answered": false,
+              "objectVersion": 0
+            }
+          ],
+          "ordinal": 3,
+          "approved": false,
+          "maxScore": null,
+          "minScore": 0.0,
+          "modified": null,
+          "modifier": null,
+          "question": {
+            "id": 253000,
+            "tags": [],
+            "type": "ClaimChoiceQuestion",
+            "state": null,
+            "parent": null,
+            "shared": false,
+            "created": null,
+            "creator": null,
+            "options": [
+              {
+                "id": 20003,
+                "option": "En osaa sanoa",
+                "defaultScore": 0,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              },
+              {
+                "id": 20002,
+                "option": "Epätosi",
+                "defaultScore": -1,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              },
+              {
+                "id": 20001,
+                "option": "Tosi",
+                "defaultScore": 1,
+                "correctOption": false,
+                "objectVersion": 0,
+                "claimChoiceType": null
+              }
+            ],
+            "modified": null,
+            "modifier": null,
+            "question": "<p>Suomi kuuluu Eurooppaan.</p>\n",
+            "attachment": null,
+            "objectVersion": 0,
+            "questionOwners": [],
+            "defaultMaxScore": null,
+            "maxDefaultScore": 1.0,
+            "minDefaultScore": -1.0,
+            "defaultEvaluationType": null,
+            "defaultExpectedWordCount": null,
+            "defaultAnswerInstructions": null,
+            "defaultEvaluationCriteria": null
+          },
+          "rejected": false,
+          "essayAnswer": null,
+          "assessedScore": 0.0,
+          "objectVersion": 0,
+          "evaluationType": null,
+          "sequenceNumber": 3,
+          "clozeTestAnswer": null,
+          "derivedMaxScore": null,
+          "maxAssessedScore": 0.0,
+          "expectedWordCount": null,
+          "answerInstructions": null,
+          "evaluationCriteria": null
         }
       ]
     }

--- a/test/resources/initial-data.yml
+++ b/test/resources/initial-data.yml
@@ -445,6 +445,20 @@ question-weighted-multiple-choice:
 
 ######################################################################
 
+question-claim-choice:
+
+  - &claim1 !!backend.models.questions.Question
+      type: ClaimChoiceQuestion
+      question: Suomen pääkaupunki on Helsinki
+      creator: *olli
+      created: 2014-01-18 12:30:05.123
+      options:
+        - &tosi !!backend.models.questions.MultipleChoiceOption {option: Tosi, defaultScore: 1, claimChoiceType: CorrectOption}
+        - &epatosi !!backend.models.questions.MultipleChoiceOption {option: Epätosi, defaultScore: -1, claimChoiceType: IncorrectOption}
+        - &eos !!backend.models.questions.MultipleChoiceOption {option: En osaa sanoa, defaultScore: 0, claimChoiceType: SkipOption}
+
+######################################################################
+
 courses:
 
   - &alkeet !!backend.models.Course
@@ -833,6 +847,11 @@ exam-sections:
     sequenceNumber: 2
     exam: *ooad
 
+  - &claimsection !!backend.models.sections.ExamSection
+    name: Väittämä-osio
+    sequenceNumber: 3
+    exam: *alkeidenperusteetGraded
+
 ######################################################################
 
 section-questions:
@@ -1184,6 +1203,15 @@ section-questions:
       - !!backend.models.sections.ExamSectionQuestionOption {option: *kumpi, score: 2}
       - !!backend.models.sections.ExamSectionQuestionOption {option: *kampi, score: 2}
       - !!backend.models.sections.ExamSectionQuestionOption {option: *molemmat, score: -2}
+
+  - !!backend.models.sections.ExamSectionQuestion
+    examSection: *claimsection
+    question: *claim1
+    sequenceNumber: 0
+    options:
+      - !!backend.models.sections.ExamSectionQuestionOption {option: *tosi, score: -1}
+      - !!backend.models.sections.ExamSectionQuestionOption {option: *epatosi, score: 1}
+      - !!backend.models.sections.ExamSectionQuestionOption {option: *eos, score: 0}
 
 ################################################################
 


### PR DESCRIPTION
- Enabled claim choice question on external and collaborative exams
- Removed option ordering on external exams to keep shuffled order, also save options in same order for assessment
- Extended unit tests by testing claim choice question examination, also externally