### PR TITLE
CSCEXAM-669: Retain order of claim choice questions on external exams

### DIFF
--- a/app/backend/controllers/iop/transfer/impl/ExternalExamController.java
+++ b/app/backend/controllers/iop/transfer/impl/ExternalExamController.java
@@ -55,6 +55,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -364,11 +365,20 @@ public class ExternalExamController extends BaseController implements ExternalEx
                             .map(Question::getType)
                             .orElseGet(null);
                         if (questionType == Question.Type.ClaimChoiceQuestion) {
-                            return;
+                            Set<ExamSectionQuestionOption> sorted = esq
+                                .getOptions()
+                                .stream()
+                                .collect(
+                                    Collectors.toCollection(
+                                        () -> new TreeSet<>(Comparator.comparingLong(esqo -> esqo.getOption().getId()))
+                                    )
+                                );
+                            esq.setOptions(sorted);
+                        } else {
+                            List<ExamSectionQuestionOption> shuffled = new ArrayList<>(esq.getOptions());
+                            Collections.shuffle(shuffled);
+                            esq.setOptions(new HashSet<>(shuffled));
                         }
-                        List<ExamSectionQuestionOption> shuffled = new ArrayList<>(esq.getOptions());
-                        Collections.shuffle(shuffled);
-                        esq.setOptions(new HashSet<>(shuffled));
                     }
                 );
 

--- a/app/backend/models/sections/ExamSectionQuestion.java
+++ b/app/backend/models/sections/ExamSectionQuestion.java
@@ -225,7 +225,15 @@ public class ExamSectionQuestion extends OwnedModel implements Comparable<ExamSe
         BeanUtils.copyProperties(this, esqCopy, "id", "options", "essayAnswer", "clozeTestAnswer");
         // This is a little bit tricky. Need to map the original question options with copied ones so they can be
         // associated with both question and exam section question options :)
-        Map<Long, MultipleChoiceOption> optionMap = new HashMap<>();
+
+        Map<Long, MultipleChoiceOption> optionMap;
+
+        if (question.getType() == Question.Type.ClaimChoiceQuestion) {
+            optionMap = new TreeMap<>();
+        } else {
+            optionMap = new HashMap<>();
+        }
+
         Question blueprint = question.copy(optionMap, hasParent);
         if (hasParent) {
             blueprint.setParent(question);

--- a/app/frontend/src/examination/question/examinationMultiChoiceQuestion.component.js
+++ b/app/frontend/src/examination/question/examinationMultiChoiceQuestion.component.js
@@ -46,15 +46,10 @@ angular.module('app.examination').component('examinationMultiChoiceQuestion', {
             const vm = this;
 
             vm.$onInit = function() {
-                if (vm.sq.question.type === 'ClaimChoiceQuestion' && !vm.isCollaborative && vm.orderOptions) {
+                if (vm.sq.question.type === 'ClaimChoiceQuestion' && vm.orderOptions) {
                     vm.sq.options.sort((a, b) => a.option.id - b.option.id);
                 } else if (vm.orderOptions) {
                     vm.sq.options.sort((a, b) => a.id - b.id);
-                }
-
-                if (vm.isCollaborative && vm.isPreview) {
-                    // Collaborative exam options have no id in preview, using id from nested option node
-                    vm.sq.options = vm.sq.options.map(opt => ({ ...opt, id: opt.option.id }));
                 }
 
                 const answered = vm.sq.options.filter(function(o) {

--- a/app/frontend/src/review/assessment/questions/claimChoiceAnswer.component.js
+++ b/app/frontend/src/review/assessment/questions/claimChoiceAnswer.component.js
@@ -25,10 +25,6 @@ angular.module('app.review').component('rClaimChoiceAnswer', {
         function(Question) {
             const vm = this;
 
-            vm.$onInit = function() {
-                vm.sectionQuestion.options.sort((a, b) => a.option.id - b.option.b).reverse();
-            };
-
             vm.getSelectedOptionClass = function(examOption) {
                 const { answered = false, option = null } = examOption;
 

--- a/app/frontend/src/review/assessment/questions/claimChoiceAnswer.template.html
+++ b/app/frontend/src/review/assessment/questions/claimChoiceAnswer.template.html
@@ -1,7 +1,7 @@
 <div
     class="padl15 marb10"
     ng-show="$ctrl.sectionQuestion.reviewExpanded"
-    ng-repeat="option in $ctrl.sectionQuestion.options"
+    ng-repeat="option in $ctrl.sectionQuestion.options | orderBy:'option.id'"
 >
     <div>
         <div ng-class="$ctrl.getSelectedOptionClass(option)">


### PR DESCRIPTION
- Sort claim choice options before providing external exam to another exam instance
- Sort claim choice mainly by MultipleChoiceOption id, not ExamSectionQuestionOption id
- Fixed option order also on preview