### PR TITLE
CSCEXAM-822 Fix issues with collaborative participation timestamps

### DIFF
--- a/app/controllers/iop/collaboration/impl/CollaborativeEnrolmentController.java
+++ b/app/controllers/iop/collaboration/impl/CollaborativeEnrolmentController.java
@@ -164,9 +164,10 @@ public class CollaborativeEnrolmentController extends CollaborationController {
     }
 
     private Optional<Result> handleFutureReservations(List<ExamEnrolment> enrolments, User user, CollaborativeExam ce) {
+        DateTime now = DateTimeUtils.adjustDST(DateTime.now());
         List<ExamEnrolment> enrolmentsWithFutureReservations = enrolments
             .stream()
-            .filter(ee -> ee.getReservation().toInterval().isAfterNow())
+            .filter(ee -> ee.getReservation().toInterval().isAfter(now))
             .collect(Collectors.toList());
         if (enrolmentsWithFutureReservations.size() > 1) {
             logger.error(
@@ -174,7 +175,7 @@ public class CollaborativeEnrolmentController extends CollaborationController {
                 user,
                 ce.getId()
             );
-            return Optional.of(internalServerError()); // Lets fail right here
+            return Optional.of(internalServerError()); // Let's fail right here
         }
         // reservation in the future, replace it
         if (!enrolmentsWithFutureReservations.isEmpty()) {

--- a/app/controllers/iop/collaboration/impl/CollaborativeExamLoaderImpl.java
+++ b/app/controllers/iop/collaboration/impl/CollaborativeExamLoaderImpl.java
@@ -100,7 +100,7 @@ public class CollaborativeExamLoaderImpl implements CollaborativeExamLoader {
     public PathProperties getAssessmentPath() {
         String path =
             "(*, user(id, firstName, lastName, email, eppn, userIdentifier)" +
-            "exam(id, name, state, instruction, hash, duration, executionType(id, type), " +
+            "exam(id, name, state, instruction, hash, implementation, duration, executionType(id, type), " +
             "examLanguages(code), attachment(id, externalId, fileName)" +
             "autoEvaluationConfig(*, gradeEvaluations(*, grade(*)))" +
             "creditType(*), examType(*), executionType(*)" +


### PR DESCRIPTION
- no info transmitted about exam implementation type
- ^needed for displaying time correctly
- also noticed that it is impossible to re-enroll a collaborative
  exam immediately after reservation ends (there is an hour's gap
  until you can)