### PR TITLE
CSCEXAM-1561 Added preservation of parent relation

### DIFF
--- a/app/controllers/exam/copy/ExamCopyContext.java
+++ b/app/controllers/exam/copy/ExamCopyContext.java
@@ -60,7 +60,7 @@ public final class ExamCopyContext {
 
     public boolean shouldSetParent() {
         // Teacher copies and non-collaborative student exams should have parent set
-        return (copyType == CopyType.TEACHER_COPY || copyType == CopyType.STUDENT_EXAM);
+        return Set.of(CopyType.TEACHER_COPY, CopyType.STUDENT_EXAM, CopyType.WITH_ANSWERS).contains(copyType);
     }
 
     public boolean shouldShuffleOptions() {

--- a/test/resources/externalExamAttainment.json
+++ b/test/resources/externalExamAttainment.json
@@ -193,7 +193,7 @@
             "modified": null,
             "modifier": null,
             "question": {
-              "id": 5555555555,
+              "id": 5,
               "tags": [],
               "type": "MultipleChoiceQuestion",
               "state": null,
@@ -411,7 +411,7 @@
             "modified": null,
             "modifier": null,
             "question": {
-              "id": 22,
+              "id": 23,
               "tags": [],
               "type": "ClozeTestQuestion",
               "state": null,
@@ -851,7 +851,7 @@
             "modified": null,
             "modifier": null,
             "question": {
-              "id": 23,
+              "id": 24,
               "tags": [],
               "type": "ClozeTestQuestion",
               "state": null,
@@ -1106,7 +1106,7 @@
             "modified": null,
             "modifier": null,
             "question": {
-              "id": 24,
+              "id": 25,
               "tags": [],
               "type": "ClozeTestQuestion",
               "state": null,


### PR DESCRIPTION
- When cloning external exam to local, questions' parent to child relation was not preserved. That caused problems in some part of the review process
- Added an assertion to existing test suite for this case
- Removal of some java-iop stuff that is no longer needed