### PR TITLE
CSCEXAM-1625 Fixed time handling in exceptions

### DIFF
--- a/ui/src/app/facility/schedule/exception-dialog.component.ts
+++ b/ui/src/app/facility/schedule/exception-dialog.component.ts
@@ -110,7 +110,7 @@ export class ExceptionDialogComponent {
 
         const result = this.parseExceptionDays(matches);
         const translations = this.dateTime.getWeekdayNames(true).map((d, i) => {
-            return { name: d, number: i === 6 ? 0 : i + 1 }; // 1-7 mo-su converted to 0-6 su-sa
+            return { name: d, number: i + 1 }; // 1-7 mo-su, as in Luxon
         });
         const message = translations.filter((d) => weekdays.includes(d.number)).map((d) => ' ' + d.name) + '.';
         this.endDialogue(message, result);

--- a/ui/src/app/facility/schedule/exception-repetition-options.component.spec.ts
+++ b/ui/src/app/facility/schedule/exception-repetition-options.component.spec.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2024 The members of the EXAM Consortium
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ExceptionDialogRepetitionOptionsComponent } from './exception-repetition-options.component';
+
+describe('ExceptionDialogRepetitionOptionsComponent', () => {
+    let component: ExceptionDialogRepetitionOptionsComponent;
+    let fixture: ComponentFixture<ExceptionDialogRepetitionOptionsComponent>;
+
+    // Days relative to today, so the pickers' initial "now" never interferes
+    const at = (days: number, hour: number, minute = 0): Date => {
+        const date = new Date();
+        date.setDate(date.getDate() + days);
+        date.setHours(hour, minute, 0, 0);
+        return date;
+    };
+
+    // Put the component in a valid state: begins in 1 day, ends in `days` days at `hour`
+    const givenRange = (days: number, hour: number) => {
+        component.endChanged({ date: at(days, hour) });
+        component.startChanged({ date: at(1, 9) });
+    };
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [ExceptionDialogRepetitionOptionsComponent, TranslateModule.forRoot()],
+            providers: [provideZonelessChangeDetection()],
+        }).compileComponents();
+
+        TestBed.inject(TranslateService).use('en');
+        fixture = TestBed.createComponent(ExceptionDialogRepetitionOptionsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    describe('start date moved past end date', () => {
+        it('should keep the ending time of day when it still comes after the starting time', () => {
+            givenRange(3, 12);
+
+            component.startChanged({ date: at(5, 9) });
+
+            expect(component.endDate()).toEqual(at(5, 12));
+        });
+
+        it('should fall back to the starting time when the ending time is earlier', () => {
+            givenRange(3, 8);
+
+            component.startChanged({ date: at(5, 14) });
+
+            expect(component.endDate()).toEqual(at(5, 14));
+        });
+
+        it('should fall back to the starting time when the times are equal', () => {
+            givenRange(3, 9);
+
+            component.startChanged({ date: at(5, 9) });
+
+            expect(component.endDate()).toEqual(at(5, 9));
+        });
+    });
+
+    it('should leave the end untouched when the start stays before it', () => {
+        givenRange(10, 12);
+
+        component.startChanged({ date: at(2, 9) });
+
+        expect(component.endDate()).toEqual(at(10, 12));
+    });
+});

--- a/ui/src/app/facility/schedule/exception-repetition-options.component.ts
+++ b/ui/src/app/facility/schedule/exception-repetition-options.component.ts
@@ -83,7 +83,7 @@ export class ExceptionDialogRepetitionOptionsComponent {
         // Initialize signals that depend on DateTimeService
         this.weekdays.set(
             this.DateTimeService.getWeekdayNames(true).map((d, i) => {
-                return { selected: false, day: d, ord: i === 6 ? 0 : i + 1 }; // 1-7 mo-su converted to 0-6 su-sa
+                return { selected: false, day: d, ord: i + 1 }; // 1-7 mo-su, as in Luxon
             }),
         );
         this.months.set(
@@ -126,7 +126,7 @@ export class ExceptionDialogRepetitionOptionsComponent {
     startChanged(e: { date: Date }) {
         this._startRaw.set(e.date);
         if (this.endDate() < e.date) {
-            this._endRaw.set(e.date);
+            this._endRaw.set(this.clampEndToStart(e.date, this._endRaw()));
         }
         this.optionChanged.emit(this.getConfig());
     }
@@ -179,5 +179,16 @@ export class ExceptionDialogRepetitionOptionsComponent {
         const wholeWeekValue = this.wholeWeek();
         this.weekdays.update((weekdays) => weekdays.map((wd) => ({ ...wd, selected: wholeWeekValue })));
         this.optionChanged.emit(this.getConfig());
+    }
+
+    // Pull the ending date onto the starting one, keeping the ending time of day when it still comes after start
+    private clampEndToStart(start: Date, end: Date): Date {
+        const candidate = DateTime.fromJSDate(start).set({
+            hour: end.getHours(),
+            minute: end.getMinutes(),
+            second: 0,
+            millisecond: 0,
+        });
+        return candidate.toMillis() > start.getTime() ? candidate.toJSDate() : start;
     }
 }

--- a/ui/src/app/facility/schedule/opening-hours.component.ts
+++ b/ui/src/app/facility/schedule/opening-hours.component.ts
@@ -39,7 +39,6 @@ interface RoomWithAddressVisibility extends ExamRoom {
 export class OpenHoursComponent {
     readonly room = input.required<ExamRoom>();
 
-    readonly weekdayNames = signal<string[]>([]);
     readonly extendedRoom = linkedSignal<RoomWithAddressVisibility | undefined>(() =>
         this.room() ? this.buildExtendedRoom(this.room()) : undefined,
     );
@@ -50,13 +49,6 @@ export class OpenHoursComponent {
     private readonly roomService = inject(RoomService);
     private readonly translate = inject(TranslateService);
     private readonly toast = inject(ToastrService);
-
-    constructor() {
-        this.weekdayNames.set(this.dateTime.getWeekdayNames());
-        this.translate.onLangChange.subscribe(() => {
-            this.weekdayNames.set(this.dateTime.getWeekdayNames());
-        });
-    }
 
     orderByWeekday(dwhs: DefaultWorkingHoursWithEditing[]) {
         const ordinal = (dwh: DefaultWorkingHours) => this.WEEKDAYS.indexOf(dwh.weekday);

--- a/ui/src/app/shared/date/date.service.spec.ts
+++ b/ui/src/app/shared/date/date.service.spec.ts
@@ -119,20 +119,25 @@ describe('DateTimeService', () => {
     describe('getWeekdayNames', () => {
         it('should return short weekday names', () => {
             const names = service.getWeekdayNames(false);
-            expect(names.length).toBe(8); // 7 days + 0 (Sunday at end)
+            expect(names.length).toBe(7); // Monday-Sunday, Sunday last
             expect(names[0]).toBeTruthy();
         });
 
         it('should return long weekday names', () => {
             const names = service.getWeekdayNames(true);
-            expect(names.length).toBe(8);
+            expect(names.length).toBe(7);
             expect(names[0].length).toBeGreaterThan(3); // Long names are longer than short
+        });
+
+        it('should not contain duplicates', () => {
+            const names = service.getWeekdayNames(true);
+            expect(new Set(names).size).toBe(names.length);
         });
 
         it('should respect current language', () => {
             translateService.use('fi');
             const names = service.getWeekdayNames(false);
-            expect(names.length).toBe(8);
+            expect(names.length).toBe(7);
         });
     });
 
@@ -171,7 +176,12 @@ describe('DateTimeService', () => {
     describe('getMonthNames', () => {
         it('should return all month names', () => {
             const months = service.getMonthNames();
-            expect(months.length).toBe(13); // 12 months + 0
+            expect(months.length).toBe(12); // January-December
+        });
+
+        it('should not contain duplicates', () => {
+            const months = service.getMonthNames();
+            expect(new Set(months).size).toBe(months.length);
         });
 
         it('should return month names in current language', () => {
@@ -184,7 +194,7 @@ describe('DateTimeService', () => {
         it('should respect language changes', () => {
             translateService.use('fi');
             const months = service.getMonthNames();
-            expect(months.length).toBe(13);
+            expect(months.length).toBe(12);
         });
     });
 

--- a/ui/src/app/shared/date/date.service.ts
+++ b/ui/src/app/shared/date/date.service.ts
@@ -48,8 +48,8 @@ export class DateTimeService {
         const lang = this.translate.getCurrentLang();
         const locale = lang.toLowerCase() + '-' + lang.toUpperCase();
         const options: Intl.DateTimeFormatOptions = { weekday: length };
-        return range(1, 7)
-            .concat(0)
+        return range(1, 6) // range is inclusive: Monday-Saturday
+            .concat(0) // Sunday last
             .map(this.getDateForWeekday)
             .map((d) => d.toLocaleDateString(locale, options));
     };
@@ -76,9 +76,7 @@ export class DateTimeService {
     getMonthNames = (): string[] => {
         const lang = this.translate.getCurrentLang();
         const locale = lang.toLowerCase() + '-' + lang.toUpperCase();
-        return range(1, 12)
-            .concat(0)
-            .map((m) => this.getLocalizedDateForMonth(m, locale).monthLong as string);
+        return range(1, 12).map((m) => this.getLocalizedDateForMonth(m, locale).monthLong as string);
     };
 
     isDST = (date: Date | string | number): boolean => {


### PR DESCRIPTION
- getWeekdayNames and getMonthNames used the inclusive range() helper as if it were exclusive and then appended the wrap-around value, yielding 8 weekdays (Sunday twice) and 13 months (December twice) in every widget fed by them.

- Weekday ordinals were also still 0-6 su-sa, matching date-fns getDay(), while the comparisons have used Luxon's 1-7 mo-su weekday since 070fb7760. Mon-Sat coincide in both schemes, so only Sunday broke: selecting it produced no exception days at all, even though the confirmation dialog announced them.

- Moving the starting date past the ending one still pulls the ending date along, but the ending time of day is now retained whenever that still leaves the exception ending after it starts. The times double as the daily window of every generated exception, so overwriting them discarded an actual setting.

- Also drop the unused weekdayNames signal from the opening hours component, along with the language change subscription that kept it up to date.