### PR TITLE
CSCEXAM-636 Fixed inconsistent statistics

### DIFF
--- a/app/features/admin/services/StatisticsService.scala
+++ b/app/features/admin/services/StatisticsService.scala
@@ -72,20 +72,33 @@ class StatisticsService @Inject() (
       .isNotNull("reservation.machine")
       .ne("noShow", true)
       .distinct
+
+    // The participation date lives on either the local or the external exam, so the department and
+    // date filters cannot be pushed into the query - apply them in memory instead.
+    def participationDate(enrolment: ExamEnrolment) =
+      Option(enrolment.externalExam).map(_.started).getOrElse(enrolment.exam.created)
+
+    def matchesFilters(enrolment: ExamEnrolment) =
+      val date = participationDate(enrolment)
+      val deptMatches = dept.forall { d =>
+        // External exams carry no local course, hence no department to match against
+        Option(enrolment.externalExam).isEmpty &&
+        Option(enrolment.exam.course).exists(c => d.split(",").contains(c.department))
+      }
+      deptMatches &&
+      start.forall(s => DateTime.parse(s, ISODateTimeFormat.dateTimeParser()).isBefore(date)) &&
+      end.forall(e =>
+        DateTime.parse(e, ISODateTimeFormat.dateTimeParser()).plusDays(1).isAfter(date)
+      )
+
     val roomMap = enrolments
+      .filter(matchesFilters)
       .groupBy { enrolment =>
         val room = enrolment.reservation.machine.room
         s"${room.id}___${room.name}"
       }
       .view
-      .mapValues { enrolmentList =>
-        enrolmentList.map { enrolment =>
-          val examStart = Option(enrolment.externalExam)
-            .map(_.started)
-            .getOrElse(enrolment.exam.created)
-          Participation(examStart)
-        }.toSet
-      }
+      .mapValues(_.map(enrolment => Participation(participationDate(enrolment))))
       .toMap
 
     // Fill in rooms with no participations
@@ -100,10 +113,28 @@ class StatisticsService @Inject() (
       start: Option[String],
       end: Option[String]
   ): (Int, Int) =
-    val query = DB.find(classOf[ExamEnrolment]).where()
-    val enrolments =
-      withFilters(query, "exam.course", "reservation.startAt", dept, start, end).distinct
-    enrolments.partition(_.noShow) match
+    // Both figures cover every enrolment that was actually due to be sat: room reservations and
+    // BYOD examination events alike. The no-show sweep flags both kinds, so they belong on the same
+    // denominator - without them, an unbounded search would count every enrolment ever made against
+    // a no-show total that only ever includes due ones. The two carry their scheduled time on
+    // different paths, hence the separate queries.
+    val reserved = withFilters(
+      DB.find(classOf[ExamEnrolment]).where().isNotNull("reservation"),
+      "exam.course",
+      "reservation.startAt",
+      dept,
+      start,
+      end
+    ).distinct
+    val byod = withFilters(
+      DB.find(classOf[ExamEnrolment]).where().isNotNull("examinationEventConfiguration"),
+      "exam.course",
+      "examinationEventConfiguration.examinationEvent.start",
+      dept,
+      start,
+      end
+    ).distinct
+    (reserved ++ byod).toList.distinctBy(_.id).partition(_.noShow) match
       case (a, b) => (a.size, b.size)
 
   def listIopReservations(
@@ -121,41 +152,67 @@ class StatisticsService @Inject() (
       )
       .toList
 
+  /** States a student's exam copy can be in once it has actually been started. Shared by the
+    * response and exam figures so that both count the same population.
+    *
+    * INITIALIZED is deliberately excluded - the copy exists but the student never began the exam,
+    * so it is neither an attempt nor a response awaiting assessment. Reaching any of these states
+    * means createFinalExam has run and written the participation record, so no separate
+    * examParticipation check is needed.
+    */
+  private val AttemptStates = List(
+    ExamState.STUDENT_STARTED,
+    ExamState.REVIEW,
+    ExamState.REVIEW_STARTED,
+    ExamState.GRADED,
+    ExamState.GRADED_LOGGED,
+    ExamState.ARCHIVED,
+    ExamState.ABORTED,
+    ExamState.DELETED,
+    ExamState.REJECTED
+  )
+
   def listPublishedExams(
       dept: Option[String],
       start: Option[String],
       end: Option[String]
   ): List[ExamInfo] =
+    val pp = PathProperties.parse("(id, course(code), parent(id, name, course(code)))")
     val query = DB
       .find(classOf[Exam])
-      .fetch("course", "code")
+      .apply(pp)
       .where()
-      .isNull("parent")
-      .isNotNull("course")
-      .in("state", ExamState.PUBLISHED, ExamState.DELETED, ExamState.ARCHIVED)
-    val exams = withFilters(query, "course", "created", dept, start, end).distinct
+      .isNotNull("parent")
+      .in("state", AttemptStates.asJava)
+    // Both filters target the student's copy rather than the template it was made from - an exam
+    // published last year can still be taken this year, and the template's own state is irrelevant.
+    val attempts = withFilters(query, "course", "created", dept, start, end).distinct
 
-    def examFilter(exam: Exam) =
-      val created          = exam.created
-      val hasValidState    = exam.state.ordinal() > ExamState.PUBLISHED.ordinal()
-      val hasParticipation = Option(exam.examParticipation).isDefined
-      hasValidState &&
-      hasParticipation &&
-      start.forall(s => DateTime.parse(s, ISODateTimeFormat.dateTimeParser()).isBefore(created)) &&
-      end.forall(e =>
-        DateTime.parse(e, ISODateTimeFormat.dateTimeParser()).plusDays(1).isAfter(created)
-      )
+    // Missing course data must not drop an attempt from the count, so fall back to the student's
+    // copy and finally to an empty code rather than filtering these rows out.
+    def courseCode(exam: Exam) = Option(exam.course).flatMap(c => Option(c.code))
 
-    exams.map(e =>
-      ExamInfo(s"[${e.course.code}] ${e.name}", e.children.asScala.count(examFilter))
-    ).toList
+    attempts
+      .groupBy(_.parent.id)
+      .values
+      .map { children =>
+        val parent = children.head.parent
+        val code   = courseCode(parent).orElse(courseCode(children.head)).getOrElse("")
+        ExamInfo(s"[$code] ${parent.name}", children.size)
+      }
+      .toList
 
   def listResponses(
       dept: Option[String],
       start: Option[String],
       end: Option[String]
   ): (Int, Int, Int) =
-    val query   = DB.find(classOf[Exam]).where().isNotNull("parent").isNotNull("course")
+    val query = DB
+      .find(classOf[Exam])
+      .where()
+      .isNotNull("parent")
+      .isNotNull("course")
+      .in("state", AttemptStates.asJava)
     val exams   = withFilters(query, "course", "created", dept, start, end).distinct
     val aborted = exams.count(_.state == ExamState.ABORTED)
     val assessed = exams.count(_.hasState(
@@ -166,7 +223,6 @@ class StatisticsService @Inject() (
       ExamState.DELETED
     ))
     val unassessed = exams.count(_.hasState(
-      ExamState.INITIALIZED,
       ExamState.STUDENT_STARTED,
       ExamState.REVIEW,
       ExamState.REVIEW_STARTED

--- a/app/repository/ExaminationRepository.scala
+++ b/app/repository/ExaminationRepository.scala
@@ -113,6 +113,19 @@ class ExaminationRepository @Inject() (
         examParticipation.started = now
         db.save(examParticipation)
 
+      // The no-show sweep flags enrolments whose exam is still INITIALIZED, which a student can
+      // legitimately progress out of afterwards - BYOD exams especially, where initialising and
+      // starting are separate steps. Sitting the exam disproves the no-show, so clear it. External
+      // reservations are left alone: their no-show has already been reported to XM and cannot be
+      // retracted from here.
+      if enrolment.noShow && Option(enrolment.reservation).flatMap(r =>
+          Option(r.externalRef)
+        ).isEmpty
+      then
+        enrolment.noShow = false
+        db.update(enrolment)
+        logger.info(s"Cleared stale no-show from enrolment ${enrolment.id} - exam was started")
+
       clone
     }
 

--- a/ui/src/app/administrative/statistics/categories/response-statistics.component.ts
+++ b/ui/src/app/administrative/statistics/categories/response-statistics.component.ts
@@ -27,7 +27,7 @@ import { StatisticsService } from 'src/app/administrative/statistics/statistics.
             <div class="col-3">
                 <strong>{{ 'i18n_unassessed_exams' | translate }}:</strong>
             </div>
-            <div class="col-9">{{ data().unAssessed }}</div>
+            <div class="col-9">{{ data().unassessed }}</div>
         </div>
         <div class="row">
             <div class="col-md-3">
@@ -41,7 +41,7 @@ import { StatisticsService } from 'src/app/administrative/statistics/statistics.
 })
 export class ResponseStatisticsComponent {
     readonly queryParams = input<QueryParams>({});
-    readonly data = signal({ assessed: 0, unAssessed: 0, aborted: 0 });
+    readonly data = signal({ assessed: 0, unassessed: 0, aborted: 0 });
 
     private readonly Statistics = inject(StatisticsService);
 

--- a/ui/src/app/administrative/statistics/statistics.service.ts
+++ b/ui/src/app/administrative/statistics/statistics.service.ts
@@ -16,7 +16,7 @@ export class StatisticsService {
     listReservations$ = (params: QueryParams) =>
         this.http.get<{ noShows: number; appearances: number }>('/app/statistics/reservations', { params: params });
     listResponses$ = (params: QueryParams) =>
-        this.http.get<{ assessed: number; unAssessed: number; aborted: number }>('/app/statistics/responses', {
+        this.http.get<{ assessed: number; unassessed: number; aborted: number }>('/app/statistics/responses', {
             params: params,
         });
     listParticipations$ = (params: QueryParams) =>

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -513,7 +513,7 @@
     "i18n_month": "Month",
     "i18n_rank": "Rank",
     "i18n_most_popular_exams": "The most taken exams",
-    "i18n_total_reservations": "Total number of exams taken",
+    "i18n_total_reservations": "Total number attended",
     "i18n_total_no_shows": "Total number of no-shows",
     "i18n_exam_responses": "Study attainments",
     "i18n_assessed_exams": "Assessed exams",

--- a/ui/src/assets/i18n/fi.json
+++ b/ui/src/assets/i18n/fi.json
@@ -513,7 +513,7 @@
     "i18n_month": "Kuukausi",
     "i18n_rank": "Sija",
     "i18n_most_popular_exams": "Suoritetuimmat tentit",
-    "i18n_total_reservations": "Suorituksia yhteensä",
+    "i18n_total_reservations": "Tentteihin saapuneita yhteensä",
     "i18n_total_no_shows": "Tenttiin saapumattomia yhteensä",
     "i18n_exam_responses": "Suoritukset",
     "i18n_assessed_exams": "Arvioidut",

--- a/ui/src/assets/i18n/sv.json
+++ b/ui/src/assets/i18n/sv.json
@@ -513,7 +513,7 @@
     "i18n_month": "Månad",
     "i18n_rank": "Ställe",
     "i18n_most_popular_exams": "Populäraste tentamina",
-    "i18n_total_reservations": "Prestationer totalt",
+    "i18n_total_reservations": "Antal närvarande totalt",
     "i18n_total_no_shows": "No-show händelser totalt",
     "i18n_exam_responses": "Prestationer",
     "i18n_assessed_exams": "Bedömd",


### PR DESCRIPTION
The statistics tabs disagreed because each counted a different population:

- The exams tab filtered on the template's state and creation date, hiding attempts whose template was not PUBLISHED/DELETED/ARCHIVED or was created outside the searched period. It now filters the student's copy instead, and defines an attempt by an explicit state list rather than by enum ordinal arithmetic, which silently depended on declaration order.

- Study attainments counted INITIALIZED copies the student never started. Both tabs now share the same state list, so they cannot drift apart.

- The students tab counted every enrolment ever made against a no-show total that only ever includes enrolments which were due, and ignored BYOD exams entirely. It now covers room reservations and examination events alike, making the no-show rate institution-wide. Labels were reworded accordingly, since the figure never was a count of exams taken.

- A student who finished an exam after the no-show sweep had flagged their INITIALIZED copy kept a stale no-show. Starting the exam now clears it, except for external reservations whose no-show has already been reported to XM and cannot be retracted locally.